### PR TITLE
fix(text-field): change label color to red when error

### DIFF
--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -97,6 +97,11 @@
 
     &--error {
       border-color: $ray-color-red-50;
+
+      .#{$ray-class-prefix}text-field__label,
+      .#{$ray-class-prefix}text-area__label {
+        color: $ray-color-red-50;
+      }
     }
 
     [disabled] {


### PR DESCRIPTION
fix #4

<img width="791" alt="Screen Shot 2019-04-16 at 8 12 02 PM" src="https://user-images.githubusercontent.com/19141291/56252078-330dc200-6084-11e9-8d1c-b47b18877cc6.png">
