### PR TITLE
feat(image): update caption styling

### DIFF
--- a/packages/core/src/components/image/_image.scss
+++ b/packages/core/src/components/image/_image.scss
@@ -41,11 +41,10 @@ $ray-image-ratio-map: (
 }
 
 .#{$ray-class-prefix}caption {
-  font-size: 0.75rem;
-  line-height: 1.25rem;
+  @include ray-body-x-small;
+
   max-height: 2.5rem;
-  font-family: $ray-font-stack-mono;
-  text-transform: uppercase;
+  color: $ray-color-gray-60;
   overflow: hidden;
   text-overflow: -o-ellipsis-lastline;
   text-overflow: ellipsis;


### PR DESCRIPTION
[GROW-7589](https://jira.weworkers.io/browse/GROW-7589)

Updates image caption styling to use ray-body-x-small instead of mono.

**Before:**
![Screen Shot 2019-04-23 at 11 59 24 AM](https://user-images.githubusercontent.com/13824279/56597263-14498700-65c0-11e9-9efe-aeaf8bcbddda.png)

**After:**
![Screen Shot 2019-04-23 at 12 04 59 PM](https://user-images.githubusercontent.com/13824279/56597249-0f84d300-65c0-11e9-8eda-45bc417167bc.png)
