### PR TITLE
feat(textarea): allow multi-row textarea

### DIFF
--- a/docs/components/text-field.md
+++ b/docs/components/text-field.md
@@ -20,7 +20,7 @@ title: Text Field
 </component>
 
 <component
-    name="Text area (with rows)"
+    name="Text area with rows"
     component="text-area"
     variation="text-area-multi-row"
     >

--- a/docs/components/text-field.md
+++ b/docs/components/text-field.md
@@ -20,6 +20,13 @@ title: Text Field
 </component>
 
 <component
+    name="Text area (with rows)"
+    component="text-area"
+    variation="text-area-multi-row"
+    >
+</component>
+
+<component
     name="Text field with hints"
     component="text-field"
     variation="text-field-with-hint"

--- a/docs/html/text-area/text-area-multi-row.html
+++ b/docs/html/text-area/text-area-multi-row.html
@@ -1,0 +1,12 @@
+<div class="ray-text-area">
+  <textarea
+    rows="4"
+    class="ray-text-area__input"
+    id="notes"
+    type="email"
+    placeholder="adding `rows` overrides default height"
+  ></textarea>
+  <label class="ray-text-area__label" for="notes">
+    Long notes
+  </label>
+</div>

--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -170,7 +170,7 @@
     }
   }
 
-  textarea[rows].#{$ray-class-prefix}text-area {
+  [rows].#{$ray-class-prefix}text-area {
     &__input {
       height: auto !important;
     }

--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -172,7 +172,8 @@
 
   [rows].#{$ray-class-prefix}text-area {
     &__input {
-      height: auto !important;
+      height: auto; // ie11 fallback
+      height: unset;
     }
   }
 }

--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -169,4 +169,10 @@
       }
     }
   }
+
+  textarea[rows].#{$ray-class-prefix}text-area {
+    &__input {
+      height: auto !important;
+    }
+  }
 }

--- a/packages/core/stories/text-field.stories.js
+++ b/packages/core/stories/text-field.stories.js
@@ -65,7 +65,7 @@ storiesOf('Text Field', module)
       <div className="ray-text-area">
         <textarea
           className="ray-text-area__input"
-          row="4"
+          rows="4"
           id="textarea"
           placeholder="Few people are aware..."
         />


### PR DESCRIPTION
when rows are provided to a textarea, the fixed height is removed and set to "auto"

<img width="857" alt="Screen Shot 2019-04-26 at 2 28 38 PM" src="https://user-images.githubusercontent.com/49030/56828599-a5726500-682f-11e9-9de6-472861f8373b.png">
