### PR TITLE
fix(select): don't move label on focus/active

### DIFF
--- a/packages/core/src/components/select/_select.scss
+++ b/packages/core/src/components/select/_select.scss
@@ -88,19 +88,8 @@
     &--active {
       border-color: $ray-color-blue-50;
 
-      .#{$ray-class-prefix}select__input {
-        color: $ray-color-black;
-      }
-
       .#{$ray-class-prefix}select__label {
-        @include label--active;
         color: $ray-color-blue-50;
-      }
-
-      &.#{$ray-class-prefix}select--placeholder-mode {
-        .#{$ray-class-prefix}select__input {
-          color: $ray-color-text-light;
-        }
       }
 
       &.#{$ray-class-prefix}select--has-value {

--- a/packages/core/src/components/select/_select.scss
+++ b/packages/core/src/components/select/_select.scss
@@ -63,6 +63,12 @@
       }
     }
 
+    &--placeholder-mode {
+      .#{$ray-class-prefix}select__input {
+        color: rgba(0, 0, 0, 0);
+      }
+    }
+
     &--has-value {
       .#{$ray-class-prefix}select__label {
         @include label--active;
@@ -88,8 +94,22 @@
     &--active {
       border-color: $ray-color-blue-50;
 
+      .#{$ray-class-prefix}select__input {
+        color: $ray-color-black;
+      }
+
       .#{$ray-class-prefix}select__label {
         color: $ray-color-blue-50;
+      }
+
+      &.#{$ray-class-prefix}select--placeholder-mode {
+        .#{$ray-class-prefix}select__label {
+          @include label--active;
+        }
+
+        .#{$ray-class-prefix}select__input {
+          color: $ray-color-text-light;
+        }
       }
 
       &.#{$ray-class-prefix}select--has-value {

--- a/packages/core/stories/select.stories.js
+++ b/packages/core/stories/select.stories.js
@@ -68,9 +68,7 @@ storiesOf('Select', module)
     return (
       <div className="ray-select">
         <select className="ray-select__input" required>
-          <option value="" disabled selected data-ray-placeholder>
-            {"Hi, I'm a placeholder"}
-          </option>
+          <option value="" disabled selected data-ray-placeholder />
           <option value="Pikatchu">Pikatchu</option>
           <option value="Squirtle">Squirtle</option>
           <option value="Charmander">Charmander</option>


### PR DESCRIPTION
fix #88

The current Select focus/active implementation moves the label up when a select is activated, but if no selection is made (and user clicks off of the select), then the label remains "activated" and only returns back to normal when the select completely loses focus. This change makes it so that the label only moves up if a selection is made.

## Current behavior

![Screen Recording 2019-05-12 at 10 24 AM](https://user-images.githubusercontent.com/49030/57583650-794a1b80-74a0-11e9-8899-16adcc4a4572.gif)

## New proposed behavior

![Screen Recording 2019-05-12 at 10 26 AM](https://user-images.githubusercontent.com/49030/57583660-8d8e1880-74a0-11e9-9158-6829b6429a74.gif)
