### PR TITLE
fix(radio-checkbox): improve legebility of radio-checkbox active states

### DIFF
--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -2,7 +2,7 @@
 @import '../../global/variables';
 
 @include exports('ray-radio-checkbox') {
-  $ray-radio-checkbox-border-width: rem(3px);
+  $ray-radio-checkbox-border-width: rem(1px);
   $ray-radio-checkbox-size: rem(16px);
   $ray-radio-checkbox-top-offset: (
       $ray-field-line-height - $ray-radio-checkbox-size
@@ -23,7 +23,7 @@
         box-sizing: border-box;
         content: '';
         background-color: $ray-color-white;
-        border: $ray-radio-checkbox-border-width double $ray-color-black;
+        border: $ray-radio-checkbox-border-width solid $ray-color-black;
         width: $ray-radio-checkbox-size;
         height: $ray-radio-checkbox-size;
         position: relative;
@@ -133,8 +133,9 @@
     content: '✓';
 
     // Needed to center the checkmark
-    text-indent: -2px;
-    line-height: 11px;
+    line-height: 14px;
+    font-size: calc(1rem - #{rem(1px)});
+    text-indent: 1px;
   }
 
   /**

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -144,12 +144,10 @@
   .#{$ray-class-prefix}radio__input:checked
     + .#{$ray-class-prefix}radio__label {
     &::before {
-      border-style: solid;
-      border-width: rem(2px);
       background-color: $ray-color-white !important;
     }
 
-    $ray-radio-dot-size: 0.4rem;
+    $ray-radio-dot-size: 0.5rem;
 
     &::after {
       content: '';

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -1,6 +1,12 @@
+@import '../../global/mixins/exports';
+@import '../../global/variables';
+
 @include exports('ray-radio-checkbox') {
   $ray-radio-checkbox-border-width: rem(3px);
   $ray-radio-checkbox-size: rem(16px);
+  $ray-radio-checkbox-top-offset: (
+      $ray-field-line-height - $ray-radio-checkbox-size
+    ) / 2;
 
   .#{$ray-class-prefix}radio,
   .#{$ray-class-prefix}checkbox {
@@ -24,7 +30,7 @@
         display: inline-block;
         margin-right: 1rem;
         // centers the input with the first line of text in the label
-        top: ($ray-field-line-height - $ray-radio-checkbox-size) / 2;
+        top: $ray-radio-checkbox-top-offset;
       }
 
       &:focus {
@@ -57,7 +63,7 @@
       &:checked + .#{$ray-class-prefix}radio__label {
         &::before {
           border-color: $ray-color-blue-50;
-          background-color: $ray-color-blue-50 !important;
+          background-color: $ray-color-blue-50;
         }
 
         &:hover + .#{$ray-class-prefix}checkbox__label,
@@ -122,5 +128,41 @@
    */
   .#{$ray-class-prefix}checkbox__label::before {
     border-radius: $ray-border-radius;
+  }
+
+  .#{$ray-class-prefix}checkbox__input:checked
+    + .#{$ray-class-prefix}checkbox__label::before {
+    color: $ray-color-white;
+    content: '✓';
+
+    // Needed to center the checkmark
+    text-indent: -2px;
+    line-height: 11px;
+  }
+
+  /**
+   * Radio
+   */
+  .#{$ray-class-prefix}radio__input:checked
+    + .#{$ray-class-prefix}radio__label {
+    &::before {
+      border-style: solid;
+      border-width: rem(2px);
+      background-color: $ray-color-white !important;
+    }
+
+    $ray-radio-dot-size: 0.4rem;
+
+    &::after {
+      content: '';
+      width: $ray-radio-dot-size;
+      height: $ray-radio-dot-size;
+      background-color: $ray-color-blue-50;
+      border-radius: $ray-radio-dot-size;
+      position: absolute;
+      top: $ray-radio-checkbox-top-offset + ($ray-radio-checkbox-size / 2) -
+        ($ray-radio-dot-size / 2);
+      left: ($ray-radio-checkbox-size / 2) - ($ray-radio-dot-size / 2);
+    }
   }
 }

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -110,9 +110,6 @@
    * Radio
    */
   .#{$ray-class-prefix}radio__label {
-    border-radius: 50%;
-    box-shadow: none;
-
     &:focus {
       outline: 0;
       box-shadow: $ray-box-shadow-focus-state;

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -89,17 +89,17 @@
         &:hover + .#{$ray-class-prefix}checkbox__label,
         &:hover + .#{$ray-class-prefix}radio__label {
           &::before {
-            background-color: $ray-color-white;
+            background-color: $ray-color-white !important;
           }
         }
 
         + .#{$ray-class-prefix}radio__label,
         + .#{$ray-class-prefix}checkbox__label {
           cursor: not-allowed;
-          color: $ray-color-gray-30;
+          color: $ray-color-gray-30 !important;
 
           &::before {
-            border-color: $ray-color-gray-30;
+            border-color: $ray-color-gray-30 !important;
           }
         }
       }

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -2,7 +2,7 @@
 @import '../../global/variables';
 
 @include exports('ray-radio-checkbox') {
-  $ray-radio-checkbox-border-width: rem(1px);
+  $ray-radio-checkbox-border-width: $ray-border-width;
   $ray-radio-checkbox-size: rem(16px);
   $ray-radio-checkbox-top-offset: (
       $ray-field-line-height - $ray-radio-checkbox-size
@@ -110,6 +110,8 @@
    * Radio
    */
   .#{$ray-class-prefix}radio__label {
+    position: relative;
+
     &:focus {
       outline: 0;
       box-shadow: $ray-box-shadow-focus-state;

--- a/packages/core/stories/radio-checkbox.stories.js
+++ b/packages/core/stories/radio-checkbox.stories.js
@@ -10,6 +10,7 @@ storiesOf('Radio & Checkbox', module)
           name="radio-button-story"
           type="radio"
           className="ray-radio__input"
+          defaultChecked
         />
         <label className="ray-radio__label" htmlFor="radio-1">
           Choose me
@@ -55,6 +56,7 @@ storiesOf('Radio & Checkbox', module)
                 name="radio-button-story"
                 type="radio"
                 className="ray-radio-pill__input"
+                defaultChecked
               />
               <label className="ray-radio-pill__label" htmlFor="radio-1">
                 One
@@ -90,12 +92,25 @@ storiesOf('Radio & Checkbox', module)
     </React.Fragment>
   ))
   .add('Checkbox', () => (
-    <div className="ray-checkbox">
-      <input id="check" type="checkbox" className="ray-checkbox__input" />
-      <label className="ray-checkbox__label" htmlFor="check">
-        Check me out
-      </label>
-    </div>
+    <>
+      <div className="ray-checkbox">
+        <input id="check" type="checkbox" className="ray-checkbox__input" />
+        <label className="ray-checkbox__label" htmlFor="check">
+          Check me out
+        </label>
+      </div>
+      <div className="ray-checkbox">
+        <input
+          id="check2"
+          type="checkbox"
+          className="ray-checkbox__input"
+          defaultChecked
+        />
+        <label className="ray-checkbox__label" htmlFor="check2">
+          Check me out
+        </label>
+      </div>
+    </>
   ))
   .add('Checkbox, multiple', () => (
     <>


### PR DESCRIPTION
The user experience of the active states was a little confusing considering it didnt follow standard visual design

the gifs are slightly old

# checkbox
### before
![](https://cl.ly/ae9c4f31a1dc/Screen%20Recording%202019-05-15%20at%2002.48%20PM.gif)
### after
![](https://cl.ly/bd377759647a/Screen%20Recording%202019-05-15%20at%2002.45%20PM.gif)

# radio
### before
![](https://cl.ly/aad8559c5c3d/Screen%20Recording%202019-05-15%20at%2002.48%20PM.gif)

### after
![](https://cl.ly/91562d9501fe/Screen%20Recording%202019-05-15%20at%2002.46%20PM.gif)