### PR TITLE
feat: support right-to-left languages

### DIFF
--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -5,9 +5,16 @@ title: Breadcrumb
 
 <page-intro>Breadcrumbs are links that act as a type of secondary navigation that reveals the user’s location in a website or Web application.</page-intro>
 
-<component 
+<component
     name="Breadcrumbs"
     component="breadcrumb"
-    variation="breadcrumbs" 
+    variation="breadcrumbs"
+    >
+</component>
+
+<component
+    name="Breadcrumbs (RTL)"
+    component="breadcrumb"
+    variation="rtl-breadcrumbs"
     >
 </component>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -8,34 +8,64 @@ status: Experimental
 
 To add an icon, use the `.ray-button__icon` class on an element, usually an svg. Buttons should always be on the right side of the text. For accessibility, it is recommended to add a `<title>` element to your svg.
 
-<component 
+<component
     name="Primary button"
     component="button"
-    variation="button--primary" 
+    variation="button--primary"
     >
 </component>
-<component 
+<component
+    name="Primary button (RTL)"
+    component="button"
+    variation="rtl-button--primary"
+    >
+</component>
+<component
     name="Secondary button"
     component="button"
-    variation="button--secondary" 
+    variation="button--secondary"
     >
 </component>
-<component 
+<component
+    name="Secondary button (RTL)"
+    component="button"
+    variation="rtl-button--secondary"
+    >
+</component>
+<component
     name="Tertiary button"
     component="button"
-    variation="button--tertiary" 
+    variation="button--tertiary"
     >
 </component>
-<component 
+<component
+    name="Tertiary button (RTL)"
+    component="button"
+    variation="rtl-button--tertiary"
+    >
+</component>
+<component
     name="Compact button"
     component="button"
-    variation="button--compact" 
+    variation="button--compact"
     >
 </component>
-<component 
+<component
+    name="Compact button (RTL)"
+    component="button"
+    variation="rtl-button--compact"
+    >
+</component>
+<component
     name="Danger button"
     component="button"
-    variation="button--danger" 
+    variation="button--danger"
+    >
+</component>
+<component
+    name="Danger button (RTL)"
+    component="button"
+    variation="rtl-button--danger"
     >
 </component>
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -13,6 +13,13 @@ title: Card
 </component>
 
 <component
+    name="Card (RTL)"
+    component="card"
+    variation="rtl-card"
+    >
+</component>
+
+<component
     name="Card as a row"
     component="card"
     variation="card--row"
@@ -20,9 +27,23 @@ title: Card
 </component>
 
 <component
+    name="Card as a row (RTL)"
+    component="card"
+    variation="rtl-card--row"
+    >
+</component>
+
+<component
     name="Card as a link"
     component="card"
     variation="card--link"
+    >
+</component>
+
+<component
+    name="Card as a link (RTL)"
+    component="card"
+    variation="rtl-card--link"
     >
 </component>
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -5,9 +5,16 @@ title: Checkbox
 
 <page-intro>A checkbox control should be used when a user has to make 0–n number of choices given many options. A checkbox is similar to a switch, however a checkbox should be used when a form requires additional actions from a user in order for their selections to take effect _or_ if a group of options can be in an indeterminate state.</page-intro>
 
-<component 
+<component
     name="Checkbox Group"
     component="checkbox"
-    variation="checkbox" 
+    variation="checkbox"
+    >
+</component>
+
+<component
+    name="Checkbox Group (RTL)"
+    component="checkbox"
+    variation="rtl-checkbox"
     >
 </component>

--- a/docs/components/fieldset.md
+++ b/docs/components/fieldset.md
@@ -17,9 +17,16 @@ The `legend.ray-fieldset__legend` element _must_ be the first child fo the `fiel
 </fieldset>
 ```
 
-<component 
+<component
     name="Example"
     component="fieldset"
-    variation="fieldset" 
+    variation="fieldset"
+    >
+</component>
+
+<component
+    name="Example (RTL)"
+    component="fieldset"
+    variation="rtl-fieldset"
     >
 </component>

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -13,9 +13,23 @@ title: Image
 </component>
 
 <component
+    name="Image 16x9 with caption (RTL)"
+    component="image"
+    variation="rtl-image--16by9"
+    >
+</component>
+
+<component
     name="Image 4x3 with caption"
     component="image"
     variation="image--4by3"
+    >
+</component>
+
+<component
+    name="Image 4x3 with caption (RTL)"
+    component="image"
+    variation="rtl-image--4by3"
     >
 </component>
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -5,17 +5,31 @@ title: Radio
 
 <page-intro>Radio buttons are an essential form control that should be used to represent two or more mutually-exclusive choices. A radio signifies a user _must_ make a choice.</page-intro>
 
-<component 
+<component
     name="Radio Group"
     component="radio"
-    variation="radio" 
+    variation="radio"
     >
 </component>
 
-<component 
+<component
+    name="Radio Group (RTL)"
+    component="radio"
+    variation="rtl-radio"
+    >
+</component>
+
+<component
     name="Radio Pill Group"
     component="radio"
-    variation="radio-group" 
+    variation="radio-group"
+    >
+</component>
+
+<component
+    name="Radio Pill Group (RTL)"
+    component="radio"
+    variation="rtl-radio-group"
     >
 </component>
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -5,31 +5,66 @@ title: Select
 
 <page-intro>Text fields within the system have a standard Size and a compact Size. Our fields are outlined and become activated with our primary color using the rules we set up in our affordances. These components have several elements, not all of which are required.</page-intro>
 
-<component 
+<component
+    name="Select (RTL)"
+    component="select"
+    variation="rtl-select"
+    >
+</component>
+
+<component
     name="With placeholder"
     component="select"
-    variation="select--with-placeholder" 
+    variation="select--with-placeholder"
     >
 </component>
 
-<component 
+<component
+    name="With placeholder (RTL)"
+    component="select"
+    variation="rtl-select--with-placeholder"
+    >
+</component>
+
+<component
     name="Compact"
     component="select"
-    variation="select--compact" 
+    variation="select--compact"
     >
 </component>
 
-<component 
+<component
+    name="Compact (RTL)"
+    component="select"
+    variation="rtl-select--compact"
+    >
+</component>
+
+<component
     name="Error"
     component="select"
-    variation="select--error" 
+    variation="select--error"
     >
 </component>
 
-<component 
+<component
+    name="Error (RTL)"
+    component="select"
+    variation="rtl-select--error"
+    >
+</component>
+
+<component
     name="With icon"
     component="select"
-    variation="select-with-icon" 
+    variation="select-with-icon"
+    >
+</component>
+
+<component
+    name="With icon (RTL)"
+    component="select"
+    variation="rtl-select-with-icon"
     >
 </component>
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -3,9 +3,16 @@ label: Component
 title: Table
 ---
 
-<component 
+<component
     name="Table"
     component="table"
-    variation="table" 
+    variation="table"
+    >
+</component>
+
+<component
+    name="Table (RTL)"
+    component="table"
+    variation="rtl-table"
     >
 </component>

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -6,13 +6,29 @@ title: Tag
 <page-intro>Tags organize content across different screens, data sets, and other interactions.</page-intro>
 
 <component
+    name="Tag"
     component="tag"
     variation="tag"
     >
 </component>
 
 <component
+    name="Tag (RTL)"
+    component="tag"
+    variation="rtl-tag"
+    >
+</component>
+
+<component
+    name="Tag as Link"
     component="tag"
     variation="tag-link"
+    >
+</component>
+
+<component
+    name="Tag as Link (RTL)"
+    component="tag"
+    variation="rtl-tag-link"
     >
 </component>

--- a/docs/components/text-field.md
+++ b/docs/components/text-field.md
@@ -13,6 +13,13 @@ title: Text Field
 </component>
 
 <component
+    name="Text field (RTL)"
+    component="text-field"
+    variation="rtl-text-field"
+    >
+</component>
+
+<component
     name="Text area"
     component="text-area"
     variation="text-area"
@@ -34,9 +41,23 @@ title: Text Field
 </component>
 
 <component
+    name="Text field with hints (RTL)"
+    component="text-field"
+    variation="rtl-text-field-with-hint"
+    >
+</component>
+
+<component
     name="Text field with icons"
     component="text-field"
     variation="text-field-with-icon"
+    >
+</component>
+
+<component
+    name="Text field with icons (RTL)"
+    component="text-field"
+    variation="rtl-text-field-with-icon"
     >
 </component>
 

--- a/docs/html/breadcrumb/rtl-breadcrumbs.html
+++ b/docs/html/breadcrumb/rtl-breadcrumbs.html
@@ -1,0 +1,13 @@
+<div dir="rtl">
+  <ul class="ray-breadcrumbs">
+    <li class="ray-breadcrumb">
+      <a href="javascript:;">דף הבית</a>
+    </li>
+    <li class="ray-breadcrumb">
+      <a href="javascript:;">תֵּל אָבִיב</a>
+    </li>
+    <li class="ray-breadcrumb">
+      <a href="javascript:;">בית ביאליק</a>
+    </li>
+  </ul>
+</div>

--- a/docs/html/button/button-rtl.html
+++ b/docs/html/button/button-rtl.html
@@ -1,0 +1,37 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--primary">לחץ עלי</button>
+  <button class="ray-button ray-button--primary">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+
+  <button class="ray-button ray-button--secondary">לחץ עלי</button>
+  <button class="ray-button ray-button--secondary">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+
+  <button class="ray-button ray-button--primary ray-button--compact">
+    לחץ עלי
+  </button>
+</div>

--- a/docs/html/button/rtl-button--compact.html
+++ b/docs/html/button/rtl-button--compact.html
@@ -1,0 +1,43 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--primary ray-button--compact">
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--primary ray-button--compact" disabled>
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--primary ray-button--compact">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+  <button class="ray-button ray-button--secondary ray-button--compact">
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--secondary ray-button--compact" disabled>
+    לחץ עלי
+  </button>
+
+  <button class="ray-button ray-button--secondary ray-button--compact" disabled>
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>

--- a/docs/html/button/rtl-button--danger.html
+++ b/docs/html/button/rtl-button--danger.html
@@ -1,0 +1,36 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--primary ray-button--danger">
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--primary ray-button--danger" disabled>
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--primary ray-button--danger">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+  <button class="ray-button ray-button--primary ray-button--danger" disabled>
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>

--- a/docs/html/button/rtl-button--primary.html
+++ b/docs/html/button/rtl-button--primary.html
@@ -1,0 +1,34 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--primary">
+    לחץ עלי
+  </button>
+  <button class="ray-button ray-button--primary" disabled>לחץ עלי</button>
+  <button class="ray-button ray-button--primary">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+  <button class="ray-button ray-button--primary" disabled>
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>

--- a/docs/html/button/rtl-button--secondary.html
+++ b/docs/html/button/rtl-button--secondary.html
@@ -1,0 +1,32 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--secondary">לחץ עלי</button>
+  <button class="ray-button ray-button--secondary" disabled>לחץ עלי</button>
+  <button class="ray-button ray-button--secondary">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+  <button class="ray-button ray-button--secondary" disabled>
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>

--- a/docs/html/button/rtl-button--tertiary.html
+++ b/docs/html/button/rtl-button--tertiary.html
@@ -1,0 +1,33 @@
+<div dir="rtl">
+  <button class="ray-button ray-button--tertiary">לחץ עלי</button>
+  <button class="ray-button ray-button--tertiary" disabled>לחץ עלי</button>
+  <button class="ray-button ray-button--tertiary">
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+
+  <button class="ray-button ray-button--tertiary" disabled>
+    לחץ עלי
+    <svg
+      class="ray-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25"
+    >
+      <g>
+        <path
+          d="M12.5,6C5.5964,6,0,12.6211,0,13.5S5.5964,21,12.5,21,25,14.4375,25,13.5,19.4036,6,12.5,6Zm0,11A3.5,3.5,0,1,1,16,13.5,3.5,3.5,0,0,1,12.5,17Z"
+        />
+      </g>
+    </svg>
+  </button>
+</div>

--- a/docs/html/card/rtl-card--link.html
+++ b/docs/html/card/rtl-card--link.html
@@ -1,0 +1,25 @@
+<div dir="rtl">
+  <a
+    href="https://wework.com"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="ray-card ray-card--link"
+    style="max-width: 400px;"
+  >
+    <div class="ray-card__image ray-image ray-image--16by9">
+      <img
+        src="https://source.unsplash.com/random/800x450?minimalist"
+        alt="card graphic"
+      />
+    </div>
+
+    <div class="ray-card__content">
+      <div class="ray-card__heading">יחד טוב יותר</div>
+
+      <div>
+        תרומה גרמנית אל לוח, דת חפש ספינות טבלאות. מלא גם תרבות לחיבור חרטומים.
+        צילום ננקטת בקר ב, עוד ביולי והגולשים.
+      </div>
+    </div>
+  </a>
+</div>

--- a/docs/html/card/rtl-card--row.html
+++ b/docs/html/card/rtl-card--row.html
@@ -1,0 +1,18 @@
+<div dir="rtl">
+  <div class="ray-card ray-card--row">
+    <div class="ray-card__image ray-image ray-image--16by9">
+      <img
+        src="https://source.unsplash.com/random/800x450?minimalist"
+        alt="card graphic"
+      />
+    </div>
+
+    <div class="ray-card__content">
+      <div class="ray-card__heading">יחד טוב יותר</div>
+      <div>
+        תרומה גרמנית אל לוח, דת חפש ספינות טבלאות. מלא גם תרבות לחיבור חרטומים.
+        צילום ננקטת בקר ב, עוד ביולי והגולשים.
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/html/card/rtl-card.html
+++ b/docs/html/card/rtl-card.html
@@ -1,0 +1,18 @@
+<div dir="rtl">
+  <div class="ray-card" style="max-width: 400px;">
+    <div class="ray-card__image ray-image ray-image--16by9">
+      <img
+        src="https://source.unsplash.com/random/800x450?minimalist"
+        alt="card graphic"
+      />
+    </div>
+
+    <div class="ray-card__content">
+      <div class="ray-card__heading">יחד טוב יותר</div>
+      <div>
+        תרומה גרמנית אל לוח, דת חפש ספינות טבלאות. מלא גם תרבות לחיבור חרטומים.
+        צילום ננקטת בקר ב, עוד ביולי והגולשים.
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/html/checkbox/rtl-checkbox.html
+++ b/docs/html/checkbox/rtl-checkbox.html
@@ -1,0 +1,34 @@
+<div dir="rtl">
+  <fieldset class="ray-fieldset">
+    <legend class="ray-fieldset__legend">אוכל מועדף</legend>
+    <div class="ray-checkbox">
+      <input
+        id="checkbox-a"
+        name="checkbox-button-story"
+        type="checkbox"
+        class="ray-checkbox__input"
+      />
+      <label class="ray-checkbox__label" for="checkbox-a">פיצה</label>
+    </div>
+
+    <div class="ray-checkbox">
+      <input
+        id="checkbox-b"
+        name="checkbox-button-story"
+        type="checkbox"
+        class="ray-checkbox__input"
+      />
+      <label class="ray-checkbox__label" for="checkbox-b">פלאפל</label>
+    </div>
+
+    <div class="ray-checkbox">
+      <input
+        id="checkbox-c"
+        name="checkbox-button-story"
+        type="checkbox"
+        class="ray-checkbox__input"
+      />
+      <label class="ray-checkbox__label" for="checkbox-c">סלט</label>
+    </div>
+  </fieldset>
+</div>

--- a/docs/html/fieldset/rtl-fieldset.html
+++ b/docs/html/fieldset/rtl-fieldset.html
@@ -1,0 +1,15 @@
+<div dir="rtl">
+  <fieldset class="ray-fieldset">
+    <legend class="ray-fieldset__legend">החיה הרוחנית</legend>
+
+    <div class="ray-radio">
+      <input id="dog-rtl" name="animal" type="radio" class="ray-radio__input" />
+      <label for="dog-rtl" class="ray-radio__label">כֶּלֶב</label>
+    </div>
+
+    <div class="ray-radio">
+      <input id="cat-rtl" name="animal" type="radio" class="ray-radio__input" />
+      <label for="cat-rtl" class="ray-radio__label">חֲתוּלָה</label>
+    </div>
+  </fieldset>
+</div>

--- a/docs/html/image/rtl-image--16by9.html
+++ b/docs/html/image/rtl-image--16by9.html
@@ -1,0 +1,13 @@
+<div dir="rtl">
+  <div style="max-width: 300px">
+    <div
+      class="ray-bg ray-bg--16by9"
+      style="background-image: url(https://source.unsplash.com/random/400x300?minimalist);"
+    ></div>
+
+    <!-- optional caption element -->
+    <div class="ray-caption">
+      מפתח בקלות מלא דת, ב העמוד משחקים סדר. מה ליום טיפול בעברית שכל. עוד תיבת.
+    </div>
+  </div>
+</div>

--- a/docs/html/image/rtl-image--4by3.html
+++ b/docs/html/image/rtl-image--4by3.html
@@ -1,0 +1,13 @@
+<div dir="rtl">
+  <div style="max-width: 300px">
+    <div
+      class="ray-bg ray-bg--4by3"
+      style="background-image: url(https://source.unsplash.com/random/800x400?minimalist);"
+    ></div>
+    <!-- optional caption element -->
+    <div class="ray-caption">
+      שנתי לחשבון מתמטיקה מתן גם. כימיה אינטרנט אנציקלופדיה אם צעד, את העיר
+      הסביבה אחר גם.
+    </div>
+  </div>
+</div>

--- a/docs/html/radio/rtl-radio-group.html
+++ b/docs/html/radio/rtl-radio-group.html
@@ -1,0 +1,40 @@
+<div dir="rtl">
+  <fieldset class="ray-fieldset">
+    <legend class="ray-fieldset__legend">אוכל מועדף</legend>
+    <div class="ray-radio-pill__wrapper">
+      <div class="ray-radio-pill">
+        <input
+          id="radio-pill-1"
+          name="radio-button-story"
+          type="radio"
+          class="ray-radio-pill__input"
+        />
+        <label class="ray-radio-pill__label" for="radio-pill-1">פיצה</label>
+      </div>
+
+      <div class="ray-radio-pill">
+        <input
+          id="radio-pill-2"
+          name="radio-button-story"
+          type="radio"
+          class="ray-radio-pill__input"
+        />
+        <label class="ray-radio-pill__label" for="radio-pill-2">
+          פלאפל
+        </label>
+      </div>
+
+      <div class="ray-radio-pill">
+        <input
+          id="radio-pill-3"
+          name="radio-button-story"
+          type="radio"
+          class="ray-radio-pill__input"
+        />
+        <label class="ray-radio-pill__label" for="radio-pill-3">
+          סלט
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/docs/html/radio/rtl-radio.html
+++ b/docs/html/radio/rtl-radio.html
@@ -1,0 +1,34 @@
+<div dir="rtl">
+  <fieldset class="ray-fieldset">
+    <legend class="ray-fieldset__legend">אוכל מועדף</legend>
+    <div class="ray-radio">
+      <input
+        id="rtl-radio-1"
+        name="radio-button-story"
+        type="radio"
+        class="ray-radio__input"
+      />
+      <label class="ray-radio__label" for="rtl-radio-1">פיצה</label>
+    </div>
+
+    <div class="ray-radio">
+      <input
+        id="rtl-radio-2"
+        name="radio-button-story"
+        type="radio"
+        class="ray-radio__input"
+      />
+      <label class="ray-radio__label" for="rtl-radio-2">פלאפל</label>
+    </div>
+
+    <div class="ray-radio">
+      <input
+        id="rtl-radio-3"
+        name="radio-button-story"
+        type="radio"
+        class="ray-radio__input"
+      />
+      <label class="ray-radio__label" for="rtl-radio-3">סלט</label>
+    </div>
+  </fieldset>
+</div>

--- a/docs/html/select/rtl-select--compact.html
+++ b/docs/html/select/rtl-select--compact.html
@@ -1,0 +1,14 @@
+<div dir="rtl">
+  <div class="ray-select ray-select--compact">
+    <select class="ray-select__input">
+      <option value="" disabled selected data-ray-placeholder></option>
+      <option value="Pikatchu">פיקציו</option>
+      <option value="Squirtle">סקווירטל</option>
+      <option value="Bulbasaur">בלבזור</option>
+    </select>
+
+    <label class="ray-select__label">
+      מה הפוקימון האהוב עליך?
+    </label>
+  </div>
+</div>

--- a/docs/html/select/rtl-select--error.html
+++ b/docs/html/select/rtl-select--error.html
@@ -1,0 +1,14 @@
+<div dir="rtl">
+  <div class="ray-select ray-select--error">
+    <select class="ray-select__input">
+      <option value="" disabled selected data-ray-placeholder></option>
+      <option value="Pikatchu">פיקציו</option>
+      <option value="Squirtle">סקווירטל</option>
+      <option value="Bulbasaur">בלבזור</option>
+    </select>
+
+    <label class="ray-select__label">
+      מה הפוקימון האהוב עליך?
+    </label>
+  </div>
+</div>

--- a/docs/html/select/rtl-select--with-placeholder.html
+++ b/docs/html/select/rtl-select--with-placeholder.html
@@ -1,0 +1,16 @@
+<div dir="rtl">
+  <div class="ray-select">
+    <select class="ray-select__input">
+      <option value="" disabled selected data-ray-placeholder>
+        מהר פיקאצ"ו, מכת ברק פיקאצ"ו -!
+      </option>
+      <option value="Pikatchu">פיקציו</option>
+      <option value="Squirtle">סקווירטל</option>
+      <option value="Bulbasaur">בלבזור</option>
+    </select>
+
+    <label class="ray-select__label">
+      מה הפוקימון האהוב עליך?
+    </label>
+  </div>
+</div>

--- a/docs/html/select/rtl-select-with-icon.html
+++ b/docs/html/select/rtl-select-with-icon.html
@@ -1,0 +1,24 @@
+<div dir="rtl">
+  <div class="ray-form-item">
+    <div class="ray-select ray-select--with-icon-start">
+      <svg class="ray-select__icon--start" viewBox="0 0 25 25">
+        <g id="budicon-profile-picture">
+          <path
+            d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"
+          />
+        </g>
+      </svg>
+      <select class="ray-select__input">
+        <option value="" disabled selected data-ray-placeholder></option>
+        <option value="WeWork">WeWork</option>
+        <option value="WeLive">WeLive</option>
+        <option value="WeGrow">WeGrow</option>
+        <option value="WeTech">WeTech</option>
+      </select>
+
+      <label class="ray-select__label">
+        יחד טוב יותר
+      </label>
+    </div>
+  </div>
+</div>

--- a/docs/html/select/rtl-select.html
+++ b/docs/html/select/rtl-select.html
@@ -1,0 +1,14 @@
+<div dir="rtl">
+  <div class="ray-select">
+    <select class="ray-select__input">
+      <option value="" disabled selected data-ray-placeholder></option>
+      <option value="Pikatchu">פיקציו</option>
+      <option value="Squirtle">סקווירטל</option>
+      <option value="Bulbasaur">בלבזור</option>
+    </select>
+
+    <label class="ray-select__label">
+      מה הפוקימון האהוב עליך?
+    </label>
+  </div>
+</div>

--- a/docs/html/select/select-with-icon.html
+++ b/docs/html/select/select-with-icon.html
@@ -1,6 +1,6 @@
 <div class="ray-form-item">
-  <div class="ray-select ray-select--with-icon-left">
-    <svg class="ray-select__icon--left" viewBox="0 0 25 25">
+  <div class="ray-select ray-select--with-icon-start">
+    <svg class="ray-select__icon--start" viewBox="0 0 25 25">
       <g id="budicon-profile-picture">
         <path
           d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"

--- a/docs/html/table/rtl-table.html
+++ b/docs/html/table/rtl-table.html
@@ -1,0 +1,20 @@
+<div dir="rtl">
+  <table class="ray-table">
+    <thead>
+      <tr>
+        <th>שֵׁם</th>
+        <th>דואר אלקטרוני</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>אריה סטארק</td>
+        <td>arya@winterfell.org</td>
+      </tr>
+      <tr>
+        <td>ג'ון שלג</td>
+        <td>jon@thewatch.org</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/html/table/table.html
+++ b/docs/html/table/table.html
@@ -7,7 +7,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>Arya Start</td>
+      <td>Arya Stark</td>
       <td>arya@winterfell.org</td>
     </tr>
     <tr>

--- a/docs/html/tag/rtl-tag-link.html
+++ b/docs/html/tag/rtl-tag-link.html
@@ -1,0 +1,3 @@
+<div dir="rtl">
+  <a href="javascript:;" class="ray-tag">ארגון</a>
+</div>

--- a/docs/html/tag/rtl-tag.html
+++ b/docs/html/tag/rtl-tag.html
@@ -1,0 +1,3 @@
+<div dir="rtl">
+  <span class="ray-tag">ארגון</span>
+</div>

--- a/docs/html/text-field/rtl-text-field-with-hint.html
+++ b/docs/html/text-field/rtl-text-field-with-hint.html
@@ -1,0 +1,18 @@
+<div dir="rtl">
+  <div class="ray-form-item">
+    <div class="ray-text-field">
+      <input
+        class="ray-text-field__input"
+        id="name-with-hint"
+        type="text"
+        placeholder="Arya Stark"
+      />
+      <label class="ray-text-field__label" for="name-with-hint">
+        שֵׁם
+      </label>
+    </div>
+    <div class="ray-form-item__hint">
+      הזן את השם שלך כאן
+    </div>
+  </div>
+</div>

--- a/docs/html/text-field/rtl-text-field-with-icon.html
+++ b/docs/html/text-field/rtl-text-field-with-icon.html
@@ -1,0 +1,45 @@
+<div dir="rtl">
+  <div class="ray-form-item">
+    <div class="ray-text-field ray-text-field--with-icon-start">
+      <svg class="ray-text-field__icon--start" viewBox="0 0 25 25">
+        <g id="budicon-profile-picture">
+          <path
+            d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"
+          />
+        </g>
+      </svg>
+
+      <input
+        type="text"
+        class="ray-text-field__input"
+        id="input-with-icon"
+        placeholder="מעטים יודעים ..."
+      />
+      <label class="ray-text-field__label" for="input-with-icon">
+        עובדה מהנה עליך
+      </label>
+    </div>
+  </div>
+
+  <div class="ray-form-item">
+    <div class="ray-text-field ray-text-field--with-icon-end">
+      <svg class="ray-text-field__icon--end" viewBox="0 0 25 25">
+        <g id="budicon-profile-picture">
+          <path
+            d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"
+          />
+        </g>
+      </svg>
+
+      <input
+        type="text"
+        class="ray-text-field__input"
+        id="input-with-icon2"
+        placeholder="מעטים יודעים ..."
+      />
+      <label class="ray-text-field__label" for="input-with-icon2">
+        עובדה מהנה עליך
+      </label>
+    </div>
+  </div>
+</div>

--- a/docs/html/text-field/rtl-text-field.html
+++ b/docs/html/text-field/rtl-text-field.html
@@ -1,0 +1,13 @@
+<div dir="rtl">
+  <div class="ray-text-field">
+    <input
+      class="ray-text-field__input"
+      id="email"
+      type="email"
+      placeholder="arya.stark@winterfell.org"
+    />
+    <label class="ray-text-field__label" for="email">
+      כתובת דוא"ל
+    </label>
+  </div>
+</div>

--- a/docs/html/text-field/text-field-with-icon.html
+++ b/docs/html/text-field/text-field-with-icon.html
@@ -1,6 +1,6 @@
 <div class="ray-form-item">
-  <div class="ray-text-field ray-text-field--with-icon-left">
-    <svg class="ray-text-field__icon--left" viewBox="0 0 25 25">
+  <div class="ray-text-field ray-text-field--with-icon-start">
+    <svg class="ray-text-field__icon--start" viewBox="0 0 25 25">
       <g id="budicon-profile-picture">
         <path
           d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"
@@ -21,8 +21,8 @@
 </div>
 
 <div class="ray-form-item">
-  <div class="ray-text-field ray-text-field--with-icon-right">
-    <svg class="ray-text-field__icon--right" viewBox="0 0 25 25">
+  <div class="ray-text-field ray-text-field--with-icon-end">
+    <svg class="ray-text-field__icon--end" viewBox="0 0 25 25">
       <g id="budicon-profile-picture">
         <path
           d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z"

--- a/packages/core/src/components/breadcrumb/_breadcrumb.scss
+++ b/packages/core/src/components/breadcrumb/_breadcrumb.scss
@@ -20,13 +20,24 @@
     &:not(:last-child) {
       margin-right: 0.5rem;
 
+      [dir='rtl'] & {
+        margin-right: 0;
+        margin-left: 0.5rem;
+      }
+
       &::after {
         margin-left: 0.5rem;
-        content: '➝';
+        content: '→';
         font-size: 1.25rem;
         position: relative;
         top: -6px;
         line-height: 1.5;
+
+        [dir='rtl'] & {
+          margin-right: 0.5rem;
+          margin-left: 0;
+          content: '←';
+        }
       }
     }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -36,6 +36,10 @@
       }
     }
 
+    // --pull-left is DEPRECATED in favor of --pull-start, and will be
+    // removed in a future release of Ray. Use of pull-left may result
+    // in confusing behavior for RTL language sensitive layouts.
+    &--pull-left,
     &--pull-start {
       margin-left: -($ray-button-h-spacing + $ray-border-width);
 
@@ -45,6 +49,10 @@
       }
     }
 
+    // --pull-right is DEPRECATED in favor of --pull-end, and will be
+    // removed in a future release of Ray. Use of pull-right may result
+    // in confusing behavior for RTL language sensitive layouts.
+    &--pull-right,
     &--pull-end {
       margin-right: -($ray-button-h-spacing + $ray-border-width);
 
@@ -156,6 +164,10 @@
     line-height: 1;
     height: auto;
 
+    // button--pull-left is DEPRECATED in favor of button--pull-start, and will
+    // be removed in a future release of Ray. Use of button--pull-left may
+    // result in confusing behavior for RTL language sensitive layouts.
+    &.#{$ray-class-prefix}button--pull-left,
     &.#{$ray-class-prefix}button--pull-start {
       margin-left: -($ray-button-h-spacing-compact + $ray-border-width);
 
@@ -165,6 +177,10 @@
       }
     }
 
+    // button--pull-right is DEPRECATED in favor of button--pull-end, and will
+    // be removed in a future release of Ray. Use of button--pull-right may
+    // result in confusing behavior for RTL language sensitive layouts.
+    &.#{$ray-class-prefix}button--pull-right,
     &.#{$ray-class-prefix}button--pull-end {
       margin-right: -($ray-button-h-spacing-compact + $ray-border-width);
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -29,14 +29,29 @@
 
     &:not(:last-of-type) {
       margin-right: 1rem;
+
+      [dir='rtl'] & {
+        margin-right: 0;
+        margin-left: 1rem;
+      }
     }
 
-    &--pull-left {
+    &--pull-start {
       margin-left: -($ray-button-h-spacing + $ray-border-width);
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: -($ray-button-h-spacing + $ray-border-width);
+      }
     }
 
-    &--pull-right {
+    &--pull-end {
       margin-right: -($ray-button-h-spacing + $ray-border-width);
+
+      [dir='rtl'] & {
+        margin-right: 0;
+        margin-left: -($ray-button-h-spacing + $ray-border-width);
+      }
     }
   }
 
@@ -141,12 +156,22 @@
     line-height: 1;
     height: auto;
 
-    &.#{$ray-class-prefix}button--pull-left {
+    &.#{$ray-class-prefix}button--pull-start {
       margin-left: -($ray-button-h-spacing-compact + $ray-border-width);
+
+      [dir='rtl'] & {
+        margin-left: inherit;
+        margin-right: -($ray-button-h-spacing-compact + $ray-border-width);
+      }
     }
 
-    &.#{$ray-class-prefix}button--pull-right {
+    &.#{$ray-class-prefix}button--pull-end {
       margin-right: -($ray-button-h-spacing-compact + $ray-border-width);
+
+      [dir='rtl'] & {
+        margin-right: inherit;
+        margin-left: -($ray-button-h-spacing-compact + $ray-border-width);
+      }
     }
   }
 
@@ -201,6 +226,11 @@
 
   &:last-child {
     margin-left: 0.5rem;
+
+    [dir='rtl'] & {
+      margin-left: 0;
+      margin-right: 0.5rem;
+    }
   }
 
   svg {

--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -5,6 +5,7 @@
 @include exports('ray-card') {
   $card-padding: 1.5rem 1rem;
   $card-border-color: $ray-color-gray-10;
+  $card-border-default: $ray-border-width solid $card-border-color;
 
   .#{$ray-class-prefix}card {
     width: 100%;
@@ -66,20 +67,27 @@
           padding: 2.5rem;
 
           &:first-child {
-            border: $ray-border-width solid $ray-color-gray-10;
+            border: $card-border-default;
             border-right: 0;
-            border-bottom-right-radius: 0;
-            border-bottom-left-radius: $ray-border-radius;
-            border-top-right-radius: 0;
-            border-top-left-radius: $ray-border-radius;
+            border-radius: $ray-border-radius 0 0 $ray-border-radius;
+
+            [dir='rtl'] & {
+              border-right: $card-border-default;
+              border-left: 0;
+              border-radius: 0 $ray-border-radius $ray-border-radius 0;
+            }
           }
 
           &:last-child {
-            border-top: $ray-border-width solid $ray-color-gray-10;
-            border-bottom-right-radius: $ray-border-radius;
-            border-top-right-radius: $ray-border-radius;
-            border-bottom-left-radius: 0;
+            border-top: $card-border-default;
+            border-radius: 0 $ray-border-radius $ray-border-radius 0;
             border-left: 0;
+
+            [dir='rtl'] & {
+              border-radius: $ray-border-radius 0 0 $ray-border-radius;
+              border-left: $card-border-default;
+              border-right: 0;
+            }
           }
         }
 
@@ -109,17 +117,17 @@
     &__content {
       flex-grow: 1;
       padding: $card-padding;
-      border-left: $ray-border-width solid $ray-color-gray-10;
-      border-right: $ray-border-width solid $ray-color-gray-10;
+      border-left: $card-border-default;
+      border-right: $card-border-default;
 
       &:first-child {
-        border-top: $ray-border-width solid $ray-color-gray-10;
+        border-top: $card-border-default;
         border-top-left-radius: $ray-border-radius;
         border-top-right-radius: $ray-border-radius;
       }
 
       &:last-child {
-        border-bottom: $ray-border-width solid $ray-color-gray-10;
+        border-bottom: $card-border-default;
         border-bottom-left-radius: $ray-border-radius;
         border-bottom-right-radius: $ray-border-radius;
       }

--- a/packages/core/src/components/form-item/_form-item.scss
+++ b/packages/core/src/components/form-item/_form-item.scss
@@ -17,6 +17,11 @@
       overflow: hidden;
       white-space: nowrap;
 
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: $ray-field-h-spacing;
+      }
+
       &--success {
         color: $ray-color-green-70;
       }

--- a/packages/core/src/components/image/_image.scss
+++ b/packages/core/src/components/image/_image.scss
@@ -53,6 +53,10 @@ $ray-image-ratio-map: (
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   margin-top: $ray-spacing-xs;
+
+  [dir='rtl'] & {
+    text-align: left;
+  }
 }
 
 .#{$ray-class-prefix}image {

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -31,6 +31,11 @@
         margin-right: 1rem;
         // centers the input with the first line of text in the label
         top: $ray-radio-checkbox-top-offset;
+
+        [dir='rtl'] & {
+          margin-right: 0;
+          margin-left: 1rem;
+        }
       }
 
       &:focus {

--- a/packages/core/src/components/radio-pill/_radio-pill.scss
+++ b/packages/core/src/components/radio-pill/_radio-pill.scss
@@ -15,12 +15,24 @@
 
     &:not(:first-child) {
       margin-left: -$ray-border-width;
+
+      [dir='rtl'] & {
+        margin-left: 0;
+        margin-right: -$ray-border-width;
+      }
     }
 
     &:first-child {
       .#{$ray-class-prefix}radio-pill__label {
         border-bottom-left-radius: $ray-border-radius;
         border-top-left-radius: $ray-border-radius;
+
+        [dir='rtl'] & {
+          border-bottom-left-radius: 0;
+          border-top-left-radius: 0;
+          border-bottom-right-radius: $ray-border-radius;
+          border-top-right-radius: $ray-border-radius;
+        }
       }
     }
 
@@ -28,6 +40,13 @@
       .#{$ray-class-prefix}radio-pill__label {
         border-bottom-right-radius: $ray-border-radius;
         border-top-right-radius: $ray-border-radius;
+
+        [dir='rtl'] & {
+          border-bottom-right-radius: 0;
+          border-top-right-radius: 0;
+          border-bottom-left-radius: $ray-border-radius;
+          border-top-left-radius: $ray-border-radius;
+        }
       }
     }
   }

--- a/packages/core/src/components/select/_select.scss
+++ b/packages/core/src/components/select/_select.scss
@@ -13,6 +13,10 @@
     height: $ray-field-height;
     display: flex;
 
+    // __icon--right is DEPRECATED in favor of __icon--end, and will be
+    // removed in a future release of Ray. Use of __icon-right may result
+    // in confusing behavior for RTL language sensitive layouts.
+    &__icon--right,
     &__icon--end {
       @include icon;
       // need to add spacing to compensate for the arrow

--- a/packages/core/src/components/select/_select.scss
+++ b/packages/core/src/components/select/_select.scss
@@ -13,10 +13,15 @@
     height: $ray-field-height;
     display: flex;
 
-    &__icon--right {
+    &__icon--end {
       @include icon;
       // need to add spacing to compensate for the arrow
       right: calc(#{$ray-field-h-spacing} * 2 + 12px);
+
+      [dir='rtl'] & {
+        right: 0;
+        left: calc(#{$ray-field-h-spacing} * 2 + 12px);
+      }
     }
 
     &::after {
@@ -33,6 +38,11 @@
       border-right: 6px solid transparent;
       border-top: 8px solid $ray-color-gray-60;
       border-radius: 2px;
+
+      [dir='rtl'] & {
+        position: unset;
+        margin-left: $ray-field-h-spacing;
+      }
     }
 
     &__label {

--- a/packages/core/src/components/table/_table.scss
+++ b/packages/core/src/components/table/_table.scss
@@ -16,6 +16,10 @@
     text-align: left;
     text-transform: uppercase;
     padding: 1rem 0;
+
+    [dir='rtl'] & {
+      text-align: right;
+    }
   }
 
   tr {

--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -123,12 +123,12 @@
 
       .#{$ray-class-prefix}text-field__label,
       .#{$ray-class-prefix}text-area__label {
-        padding-top: $ray-field-v-spacing-compact;
+        padding-block-start: $ray-field-v-spacing-compact;
       }
 
       .#{$ray-class-prefix}text-field__input,
       .#{$ray-class-prefix}text-area__input {
-        padding-top: 0;
+        padding-block-start: 0;
 
         // separate selector to support IE11
         &:focus {
@@ -154,7 +154,7 @@
     &__input {
       overflow-y: scroll;
       display: inline-block;
-      padding-top: ($ray-field-height - $ray-field-line-height) / 2;
+      padding-block-start: ($ray-field-height - $ray-field-line-height) / 2;
       resize: vertical;
       line-height: $ray-field-line-height;
       height: $ray-field-height - 2 * $ray-border-width;
@@ -165,7 +165,7 @@
       line-height: 0;
 
       .#{$ray-class-prefix}text-area__input {
-        padding-top: ($ray-field-v-spacing-compact) / 2;
+        padding-block-start: ($ray-field-v-spacing-compact) / 2;
         height: $ray-field-height-compact - 2 * $ray-border-width;
         min-height: $ray-field-height-compact - 2 * $ray-border-width;
       }

--- a/packages/core/src/components/text-field/_text-field.scss
+++ b/packages/core/src/components/text-field/_text-field.scss
@@ -123,12 +123,12 @@
 
       .#{$ray-class-prefix}text-field__label,
       .#{$ray-class-prefix}text-area__label {
-        padding-block-start: $ray-field-v-spacing-compact;
+        padding-top: $ray-field-v-spacing-compact;
       }
 
       .#{$ray-class-prefix}text-field__input,
       .#{$ray-class-prefix}text-area__input {
-        padding-block-start: 0;
+        padding-top: 0;
 
         // separate selector to support IE11
         &:focus {
@@ -154,7 +154,7 @@
     &__input {
       overflow-y: scroll;
       display: inline-block;
-      padding-block-start: ($ray-field-height - $ray-field-line-height) / 2;
+      padding-top: ($ray-field-height - $ray-field-line-height) / 2;
       resize: vertical;
       line-height: $ray-field-line-height;
       height: $ray-field-height - 2 * $ray-border-width;
@@ -165,7 +165,7 @@
       line-height: 0;
 
       .#{$ray-class-prefix}text-area__input {
-        padding-block-start: ($ray-field-v-spacing-compact) / 2;
+        padding-top: ($ray-field-v-spacing-compact) / 2;
         height: $ray-field-height-compact - 2 * $ray-border-width;
         min-height: $ray-field-height-compact - 2 * $ray-border-width;
       }

--- a/packages/core/src/global/mixins/_form-items.scss
+++ b/packages/core/src/global/mixins/_form-items.scss
@@ -179,6 +179,10 @@
   }
 }
 @mixin icon-support($class) {
+  // --with-icon-left is DEPRECATED in favor of --with-icon-start, and will
+  // be removed in a future release of Ray. Use of --with-icon-left may
+  // result in confusing behavior for RTL language sensitive layouts.
+  &--with-icon-left,
   &--with-icon-start {
     .#{$ray-class-prefix}#{$class}__input,
     .#{$ray-class-prefix}#{$class}__label {
@@ -195,6 +199,10 @@
     }
   }
 
+  // --with-icon-right is DEPRECATED in favor of --with-icon-end, and will
+  // be removed in a future release of Ray. Use of --with-icon-right may
+  // result in confusing behavior for RTL language sensitive layouts.
+  &--with-icon-right,
   &--with-icon-end {
     .#{$ray-class-prefix}#{$class}__input,
     .#{$ray-class-prefix}#{$class}__label {
@@ -211,6 +219,8 @@
     }
   }
 
+  &--with-icon-left,
+  &--with-icon-right,
   &--with-icon-start,
   &--with-icon-end {
     fill: $ray-color-text-medium;
@@ -220,6 +230,10 @@
     }
   }
 
+  // __icon--left is DEPRECATED in favor of __icon--start, and will
+  // be removed in a future release of Ray. Use of __icon--left may
+  // result in confusing behavior for RTL language sensitive layouts.
+  &__icon-left,
   &__icon--start {
     @include icon;
     left: $ray-field-h-spacing;
@@ -230,6 +244,10 @@
     }
   }
 
+  // __icon--left is DEPRECATED in favor of __icon--start, and will
+  // be removed in a future release of Ray. Use of __icon--left may
+  // result in confusing behavior for RTL language sensitive layouts.
+  &__icon--right,
   &__icon--end {
     @include icon;
     right: $ray-field-h-spacing;
@@ -241,6 +259,8 @@
   }
 
   &--compact {
+    .#{$ray-class-prefix}#{$class}__icon--left,
+    .#{$ray-class-prefix}#{$class}__icon--right,
     .#{$ray-class-prefix}#{$class}__icon--start,
     .#{$ray-class-prefix}#{$class}__icon--end {
       top: $ray-field-v-spacing-compact;
@@ -248,6 +268,8 @@
   }
 
   &--active {
+    .#{$ray-class-prefix}#{$class}__icon--left,
+    .#{$ray-class-prefix}#{$class}__icon--right,
     .#{$ray-class-prefix}#{$class}__icon--start,
     .#{$ray-class-prefix}#{$class}__icon--end {
       fill: $ray-color-blue-50;
@@ -259,6 +281,8 @@
   }
 
   &--disabled {
+    .#{$ray-class-prefix}#{$class}__icon--left,
+    .#{$ray-class-prefix}#{$class}__icon--right,
     .#{$ray-class-prefix}#{$class}__icon--start,
     .#{$ray-class-prefix}#{$class}__icon--end {
       fill: rgba($ray-color-gray-60, 0.4);

--- a/packages/core/src/global/mixins/_form-items.scss
+++ b/packages/core/src/global/mixins/_form-items.scss
@@ -23,6 +23,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  [dir='rtl'] & {
+    left: auto;
+    right: 0;
+  }
 }
 
 @mixin label--active {
@@ -38,6 +43,11 @@
   height: auto;
   background: transparent;
 
+  [dir='rtl'] & {
+    left: auto;
+    right: $ray-field-h-spacing / 2;
+  }
+
   &::before {
     content: '';
     width: calc(100% + #{$ray-field-h-spacing} / 2);
@@ -47,6 +57,11 @@
     top: 0.25rem;
     left: -1 * $ray-field-h-spacing / 2;
     z-index: -1;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: -1 * $ray-field-h-spacing / 2;
+    }
   }
 }
 
@@ -164,26 +179,40 @@
   }
 }
 @mixin icon-support($class) {
-  &--with-icon-left {
+  &--with-icon-start {
     .#{$ray-class-prefix}#{$class}__input,
     .#{$ray-class-prefix}#{$class}__label {
       padding-left: calc(
         #{$ray-field-h-spacing} * 2 + #{$ray-field-icon-width}
       );
+
+      [dir='rtl'] & {
+        padding-left: auto;
+        padding-right: calc(
+          #{$ray-field-h-spacing} * 2 + #{$ray-field-icon-width}
+        );
+      }
     }
   }
 
-  &--with-icon-right {
+  &--with-icon-end {
     .#{$ray-class-prefix}#{$class}__input,
     .#{$ray-class-prefix}#{$class}__label {
       padding-right: calc(
         #{$ray-field-h-spacing} * 2 + #{$ray-field-icon-width}
       );
+
+      [dir='rtl'] & {
+        padding-right: auto;
+        padding-left: calc(
+          #{$ray-field-h-spacing} * 2 + #{$ray-field-icon-width}
+        );
+      }
     }
   }
 
-  &--with-icon-left,
-  &--with-icon-right {
+  &--with-icon-start,
+  &--with-icon-end {
     fill: $ray-color-text-medium;
 
     path {
@@ -191,26 +220,36 @@
     }
   }
 
-  &__icon--left {
+  &__icon--start {
     @include icon;
     left: $ray-field-h-spacing;
+
+    [dir='rtl'] & {
+      left: auto;
+      right: $ray-field-h-spacing;
+    }
   }
 
-  &__icon--right {
+  &__icon--end {
     @include icon;
     right: $ray-field-h-spacing;
+
+    [dir='rtl'] & {
+      right: auto;
+      left: $ray-field-h-spacing;
+    }
   }
 
   &--compact {
-    .#{$ray-class-prefix}#{$class}__icon--left,
-    .#{$ray-class-prefix}#{$class}__icon--right {
+    .#{$ray-class-prefix}#{$class}__icon--start,
+    .#{$ray-class-prefix}#{$class}__icon--end {
       top: $ray-field-v-spacing-compact;
     }
   }
 
   &--active {
-    .#{$ray-class-prefix}#{$class}__icon--left,
-    .#{$ray-class-prefix}#{$class}__icon--right {
+    .#{$ray-class-prefix}#{$class}__icon--start,
+    .#{$ray-class-prefix}#{$class}__icon--end {
       fill: $ray-color-blue-50;
 
       path {
@@ -220,8 +259,8 @@
   }
 
   &--disabled {
-    .#{$ray-class-prefix}#{$class}__icon--left,
-    .#{$ray-class-prefix}#{$class}__icon--right {
+    .#{$ray-class-prefix}#{$class}__icon--start,
+    .#{$ray-class-prefix}#{$class}__icon--end {
       fill: rgba($ray-color-gray-60, 0.4);
 
       path {
@@ -237,6 +276,11 @@
       &::after {
         content: '*';
         padding-left: 3px;
+
+        [dir='rtl'] & {
+          padding-left: auto;
+          padding-right: 3px;
+        }
       }
     }
   }

--- a/packages/core/stories/select.stories.js
+++ b/packages/core/stories/select.stories.js
@@ -206,8 +206,8 @@ storiesOf('Select', module)
     return (
       <>
         <div className="ray-form-item">
-          <div className="ray-select ray-select--with-icon-left">
-            <div className="ray-select__icon--left">😜</div>
+          <div className="ray-select ray-select--with-icon-start">
+            <div className="ray-select__icon--start">😜</div>
 
             <select className="ray-select__input">
               <option value="" disabled selected data-ray-placeholder />
@@ -224,9 +224,9 @@ storiesOf('Select', module)
         </div>
 
         <div className="ray-form-item">
-          <div className="ray-select ray-select--with-icon-left ray-select--with-icon-right">
+          <div className="ray-select ray-select--with-icon-start ray-select--with-icon-end">
             <svg
-              className="ray-select__icon--left"
+              className="ray-select__icon--start"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 25 25"
             >
@@ -234,7 +234,7 @@ storiesOf('Select', module)
                 <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
               </g>
             </svg>
-            <div className="ray-select__icon--right">👽</div>
+            <div className="ray-select__icon--end">👽</div>
 
             <select className="ray-select__input">
               <option value="" disabled selected data-ray-placeholder />
@@ -251,8 +251,8 @@ storiesOf('Select', module)
         </div>
 
         <div className="ray-form-item">
-          <div className="ray-select ray-select--with-icon-right">
-            <div className="ray-select__icon--right">🙏</div>
+          <div className="ray-select ray-select--with-icon-end">
+            <div className="ray-select__icon--end">🙏</div>
 
             <select className="ray-select__input">
               <option value="" disabled selected data-ray-placeholder />
@@ -269,8 +269,8 @@ storiesOf('Select', module)
         </div>
 
         <div className="ray-form-item">
-          <div className="ray-select ray-select--compact ray-select--with-icon-left">
-            <div className="ray-select__icon--left">🏂</div>
+          <div className="ray-select ray-select--compact ray-select--with-icon-start">
+            <div className="ray-select__icon--start">🏂</div>
 
             <select className="ray-select__input">
               <option value="" disabled selected data-ray-placeholder />

--- a/packages/core/stories/text-field.stories.js
+++ b/packages/core/stories/text-field.stories.js
@@ -353,9 +353,9 @@ storiesOf('Text Field', module)
     return (
       <>
         <div className="ray-form-item">
-          <div className="ray-text-field ray-text-field--with-icon-left">
+          <div className="ray-text-field ray-text-field--with-icon-start">
             <svg
-              className="ray-text-field__icon--left"
+              className="ray-text-field__icon--start"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 25 25"
             >
@@ -376,9 +376,9 @@ storiesOf('Text Field', module)
           </div>
         </div>{' '}
         <div className="ray-form-item">
-          <div className="ray-text-field ray-text-field--disabled ray-text-field--with-icon-left">
+          <div className="ray-text-field ray-text-field--disabled ray-text-field--with-icon-start">
             <svg
-              className="ray-text-field__icon--left"
+              className="ray-text-field__icon--start"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 25 25"
             >

--- a/packages/docs-app/src/components/PageHeader/PageHeader.js
+++ b/packages/docs-app/src/components/PageHeader/PageHeader.js
@@ -34,7 +34,7 @@ export default class PageHeader extends React.Component {
                 </h1>
                 {githubPath && (
                   <a
-                    className="ray-button ray-button--tertiary ray-button--compact ray-button--pull-right"
+                    className="ray-button ray-button--tertiary ray-button--compact ray-button--pull-end"
                     href={githubPath}
                     target="_blank"
                     rel="noopener noreferrer"


### PR DESCRIPTION
This makes the Ray component styles sensitive to direction, such that components will render in the
expected orientation for right-to-left languages. Ideally, this would have been done using CSS' new
Logical Properties, but support for these is not pervasive yet, so style overrides are applied using
parent selectors wherever a left-right asymmetrical style is applied. The examples have been
extended to show every component with Hebrew right-to-left rendering.

BREAKING CHANGE: Component modifiers that ended in "left" or "right" have been changed to "start"
and "end" respectively, to communicate the alignment relative to the expected flow of text in the
host language. All examples have been updated, but any clients using Ray will likely need to be
updated. Alternatively, we could temporarily alias make "left" == "start" and "right" == "end"
semantically, until we can fully deprecate those styles.