### PR TITLE
fix(card): remove overflow hidden for Safari fix

### DIFF
--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -10,7 +10,6 @@
     width: 100%;
     border-radius: $ray-border-radius;
     background-color: $ray-color-white;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
     position: relative;


### PR DESCRIPTION
The bottom border was not showing in some scenarios in Safari. This `overflow: hidden` doesn't seem needed and fixes it

BEFORE:
![Screen Shot 2019-05-23 at 11 27 59 AM](https://user-images.githubusercontent.com/19141291/58265549-e5087000-7d4d-11e9-9050-43d568d81199.png)


AFTER:
![Screen Shot 2019-05-23 at 11 27 39 AM](https://user-images.githubusercontent.com/19141291/58265558-e76aca00-7d4d-11e9-8a0c-a974aef6e628.png)
