### PR TITLE
fix(checkbox): standardize check icon

### DIFF
--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -135,14 +135,22 @@
   }
 
   .#{$ray-class-prefix}checkbox__input:checked
-    + .#{$ray-class-prefix}checkbox__label::before {
-    color: $ray-color-white;
-    content: '✓';
+    + .#{$ray-class-prefix}checkbox__label::after {
+    content: '';
+    border-right: 2px solid white;
+    border-bottom: 2px solid white;
+    transform: rotate(31deg);
+    position: absolute;
+    left: 5px;
+    top: 8px;
+    width: 3px;
+    border-radius: 0px;
+    height: 9px;
 
-    // Needed to center the checkmark
-    line-height: 14px;
-    font-size: calc(1rem - #{rem(1px)});
-    text-indent: 1px;
+    [dir='rtl'] & {
+      left: auto;
+      right: 5px;
+    }
   }
 
   /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6812331/58513878-876d8c80-816e-11e9-82d0-704d8f4a5cb3.png)

Different browsers have slightly different ascii check icon. This uses a css check icon so they all render the same