### PR TITLE
fix(card): normalize font-weight of card--row heading

### DIFF
--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -99,6 +99,7 @@
 
         .#{$ray-class-prefix}card__heading {
           @include ray-h2;
+          font-weight: 400;
         }
 
         .#{$ray-class-prefix}card__image {


### PR DESCRIPTION
This is done so the card--row matches the original card
# before

![image](https://user-images.githubusercontent.com/6812331/58725320-d9035a80-83ac-11e9-8bb8-2a60d794ecf8.png)


# after

![image](https://user-images.githubusercontent.com/6812331/58725301-cb4dd500-83ac-11e9-9d2c-5a18f5d7d55f.png)
