### PR TITLE
feat(accessibility): only show active states when keyboard navigating

### DIFF
--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -17,8 +17,6 @@ If the user is using a keyboard to navigate, Ray will apply a class to the docum
 
 The [Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG) state that to ensure readability, text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
 
-[Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG)
-
 ### Color Blindness
 
 The most common variety of colorblindness is red-green color blindness. It's important to **avoid** juxtaposing these colors.

--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -21,7 +21,7 @@ The WCAG state that to ensure readability, text and interactive elements should 
 
 ### Color Blindness
 
-The most common variety of colorblindness is red-green color blindness. It's important to **avoid** juxtaposing these color.
+The most common variety of colorblindness is red-green color blindness. It's important to **avoid** juxtaposing these colors.
 
 [US Government Standards](https://designsystem.digital.gov/design-tokens/color/overview/)
 

--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -15,7 +15,7 @@ If the user is using a keyboard to navigate, Ray will apply a class to the docum
 
 ### Color Ratio
 
-The WCAG state that to ensure readability, text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
+The [Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG) state that to ensure readability, text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
 
 [Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG)
 

--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -7,7 +7,7 @@ title: Accessibility
 
 ### Keyboard Navigation
 
-Many people navigate the web using technologies such as screen readers, or are unable to use a traditional mouse. It's imperative that content and interactive elements are accessible by way of keyboard navigation, and clearly indicate when
+Many people navigate the web using technologies such as screen readers, or are unable to use a traditional mouse. It's imperative that content and interactive elements are accessible by way of keyboard navigation, and clearly indicate where the user has focus.
 
 Do not remove focus states from elements unless you implement a suitable replacement.
 

--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -15,7 +15,7 @@ If the user is using a keyboard to navigate, Ray will apply a class to the docum
 
 ### Color Ratio
 
-The WCAG state to ensure readability that text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
+The WCAG state that to ensure readability, text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
 
 [Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG)
 

--- a/docs/foundations/accessibility.md
+++ b/docs/foundations/accessibility.md
@@ -1,0 +1,33 @@
+---
+label: Guidelines
+title: Accessibility
+---
+
+<page-intro>We believe the web is for everyone. For this reason, accessibility is treated as a first-class citizen in this system. All styles and scripts are developed to be usable, regardless of disability or device.</page-intro>
+
+### Keyboard Navigation
+
+Many people navigate the web using technologies such as screen readers, or are unable to use a traditional mouse. It's imperative that content and interactive elements are accessible by way of keyboard navigation, and clearly indicate when
+
+Do not remove focus states from elements unless you implement a suitable replacement.
+
+If the user is using a keyboard to navigate, Ray will apply a class to the document's body element that enables focus states on various components, otherwise these styles are hidden to avoid visual clutter.
+
+### Color Ratio
+
+The WCAG state to ensure readability that text and interactive elements should maintain a color contrast ratio of at least 4.5:1.
+
+[Web Content Accessibility Guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG)
+
+### Color Blindness
+
+The most common variety of colorblindness is red-green color blindness. It's important to **avoid** juxtaposing these color.
+
+[US Government Standards](https://designsystem.digital.gov/design-tokens/color/overview/)
+
+### Images
+
+If a graphic (this includes icons) is relevant to the content or user experience, it should use an `<img />` with an `alt` attribute.
+
+- Avoid background images unless they are used purely for aesthetic purposes as they are not parsed by screen readers
+- Avoid including text in images as they cannot be parsed by screen readers

--- a/packages/core/.storybook/config.js
+++ b/packages/core/.storybook/config.js
@@ -3,9 +3,7 @@ import { configure, addDecorator, addParameters } from '@storybook/react';
 import 'storybook-chromatic';
 
 import '../stories/styles/index.scss';
-import boot from '../src/global/js/boot';
-
-boot();
+import '../src/';
 
 const req = require.context('../stories', true, /.stories.js$/);
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -72,7 +72,7 @@
       border-color: $ray-color-blue-60;
     }
 
-    &:focus {
+    .#{$ray-accessibility-class} &:focus {
       box-shadow: $ray-box-shadow-focus-state;
     }
 
@@ -96,7 +96,7 @@
         border-color: $ray-color-red-60;
       }
 
-      &:focus {
+      .#{$ray-accessibility-class} &:focus {
         box-shadow: 0 0 0 3px transparentize($ray-color-red-50, 0.75);
       }
 
@@ -121,7 +121,7 @@
       background-color: $ray-color-blue-10;
     }
 
-    &:focus {
+    .#{$ray-accessibility-class} &:focus {
       box-shadow: $ray-box-shadow-focus-state;
     }
 
@@ -137,7 +137,7 @@
         background-color: $ray-color-red-10;
       }
 
-      &:focus {
+      .#{$ray-accessibility-class} &:focus {
         box-shadow: 0 0 0 3px transparentize($ray-color-red-50, 0.75);
       }
 
@@ -200,7 +200,7 @@
       background-color: $ray-color-gray-03;
     }
 
-    &:focus {
+    .#{$ray-accessibility-class} &:focus {
       box-shadow: $ray-box-shadow-focus-state;
     }
 
@@ -211,7 +211,7 @@
     &.#{$ray-class-prefix}button--danger {
       color: $ray-color-red-50;
 
-      &:focus {
+      .#{$ray-accessibility-class} &:focus {
         box-shadow: 0 0 0 3px transparentize($ray-color-red-50, 0.75);
       }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -67,9 +67,11 @@
     background-color: $ray-color-blue-50;
     color: $ray-color-white;
 
-    &:hover {
-      background-color: $ray-color-blue-60;
-      border-color: $ray-color-blue-60;
+    @include ray-breakpoint(desktop) {
+      &:hover {
+        background-color: $ray-color-blue-60;
+        border-color: $ray-color-blue-60;
+      }
     }
 
     .#{$ray-accessibility-class} &:focus {
@@ -91,9 +93,11 @@
       background-color: $ray-color-red-50;
       border-color: $ray-color-red-50;
 
-      &:hover {
-        background-color: $ray-color-red-60;
-        border-color: $ray-color-red-60;
+      @include ray-breakpoint(desktop) {
+        &:hover {
+          background-color: $ray-color-red-60;
+          border-color: $ray-color-red-60;
+        }
       }
 
       .#{$ray-accessibility-class} &:focus {
@@ -117,8 +121,10 @@
     color: $ray-color-blue-50;
     background-color: $ray-color-white;
 
-    &:hover {
-      background-color: $ray-color-blue-10;
+    @include ray-breakpoint(desktop) {
+      &:hover {
+        background-color: $ray-color-blue-10;
+      }
     }
 
     .#{$ray-accessibility-class} &:focus {
@@ -133,8 +139,10 @@
       border-color: $ray-color-red-50;
       color: $ray-color-red-50;
 
-      &:hover {
-        background-color: $ray-color-red-10;
+      @include ray-breakpoint(desktop) {
+        &:hover {
+          background-color: $ray-color-red-10;
+        }
       }
 
       .#{$ray-accessibility-class} &:focus {
@@ -196,8 +204,10 @@
     background-color: transparent;
     border-color: transparent;
 
-    &:hover {
-      background-color: $ray-color-gray-03;
+    @include ray-breakpoint(desktop) {
+      &:hover {
+        background-color: $ray-color-gray-03;
+      }
     }
 
     .#{$ray-accessibility-class} &:focus {

--- a/packages/core/src/global/_variables.scss
+++ b/packages/core/src/global/_variables.scss
@@ -9,7 +9,7 @@ $ray-font-stack-mono: 'Apercu Mono', SFMono-Regular, Menlo, Monaco, Consolas,
   'Liberation Mono', 'Courier New', monospace;
 $ray-base-font-size: rem(16px);
 $ray-base-line-height: 1.618;
-$ray-accessibility-class: 'js-#{$ray-class-prefix}keyboard-nav';
+$ray-accessibility-class: 'js-ray-enable-accessibility';
 
 $ray-assign-typography-styles-natively: true !default;
 $ray-link-color: $ray-color-blue-50;

--- a/packages/core/src/global/_variables.scss
+++ b/packages/core/src/global/_variables.scss
@@ -9,6 +9,7 @@ $ray-font-stack-mono: 'Apercu Mono', SFMono-Regular, Menlo, Monaco, Consolas,
   'Liberation Mono', 'Courier New', monospace;
 $ray-base-font-size: rem(16px);
 $ray-base-line-height: 1.618;
+$ray-accessibility-class: 'js-#{$ray-class-prefix}keyboard-nav';
 
 $ray-assign-typography-styles-natively: true !default;
 $ray-link-color: $ray-color-blue-50;

--- a/packages/core/src/global/js/accessibility.js
+++ b/packages/core/src/global/js/accessibility.js
@@ -1,16 +1,20 @@
-if (typeof document !== 'undefined') {
-  document.addEventListener('mousedown', removeAccessibilityClass);
-  document.addEventListener('keydown', addAccessibilityClass);
+function setupAccessibility() {
+  if (typeof document !== 'undefined') {
+    document.addEventListener('mousedown', removeAccessibilityClass);
+    document.addEventListener('keydown', addAccessibilityClass);
+  }
+
+  const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
+
+  // Let the document know when the mouse is being used,
+  // so accessibility styling can be removed.
+  function addAccessibilityClass() {
+    document.body.classList.add(ACCESSIBILITY_CLASS);
+  }
+
+  function removeAccessibilityClass() {
+    document.body.classList.remove(ACCESSIBILITY_CLASS);
+  }
 }
 
-const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
-
-// Let the document know when the mouse is being used,
-// so accessibility styling can be removed.
-function addAccessibilityClass() {
-  document.body.classList.add(ACCESSIBILITY_CLASS);
-}
-
-function removeAccessibilityClass() {
-  document.body.classList.remove(ACCESSIBILITY_CLASS);
-}
+export default setupAccessibility;

--- a/packages/core/src/global/js/accessibility.js
+++ b/packages/core/src/global/js/accessibility.js
@@ -1,19 +1,21 @@
+/* eslint-disable no-inner-declarations */
+
 function setupAccessibility() {
   if (typeof document !== 'undefined') {
     document.addEventListener('mousedown', removeAccessibilityClass);
     document.addEventListener('keydown', addAccessibilityClass);
-  }
 
-  const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
+    const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
 
-  // Let the document know when the mouse is being used,
-  // so accessibility styling can be removed.
-  function addAccessibilityClass() {
-    document.body.classList.add(ACCESSIBILITY_CLASS);
-  }
+    // Let the document know when the mouse is being used,
+    // so accessibility styling can be removed.
+    function addAccessibilityClass() {
+      document.body.classList.add(ACCESSIBILITY_CLASS);
+    }
 
-  function removeAccessibilityClass() {
-    document.body.classList.remove(ACCESSIBILITY_CLASS);
+    function removeAccessibilityClass() {
+      document.body.classList.remove(ACCESSIBILITY_CLASS);
+    }
   }
 }
 

--- a/packages/core/src/global/js/accessibility.js
+++ b/packages/core/src/global/js/accessibility.js
@@ -1,3 +1,8 @@
+if (typeof document !== 'undefined') {
+  document.addEventListener('mousedown', removeAccessibilityClass);
+  document.addEventListener('keydown', addAccessibilityClass);
+}
+
 const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
 
 // Let the document know when the mouse is being used,
@@ -9,6 +14,3 @@ function addAccessibilityClass() {
 function removeAccessibilityClass() {
   document.body.classList.remove(ACCESSIBILITY_CLASS);
 }
-
-document.addEventListener('mousedown', removeAccessibilityClass);
-document.addEventListener('keydown', addAccessibilityClass);

--- a/packages/core/src/global/js/accessibility.js
+++ b/packages/core/src/global/js/accessibility.js
@@ -1,22 +1,15 @@
-/* eslint-disable no-inner-declarations */
-
-function setupAccessibility() {
+function attachAccessibilityEvents() {
   if (typeof document !== 'undefined') {
-    document.addEventListener('mousedown', removeAccessibilityClass);
-    document.addEventListener('keydown', addAccessibilityClass);
+    const ENABLE_ACCESSIBILITY_CLASS = 'js-ray-enable-accessibility';
 
-    const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
+    document.addEventListener('keydown', function addAccessibilityClass() {
+      document.body.classList.add(ENABLE_ACCESSIBILITY_CLASS);
+    });
 
-    // Let the document know when the mouse is being used,
-    // so accessibility styling can be removed.
-    function addAccessibilityClass() {
-      document.body.classList.add(ACCESSIBILITY_CLASS);
-    }
-
-    function removeAccessibilityClass() {
-      document.body.classList.remove(ACCESSIBILITY_CLASS);
-    }
+    document.addEventListener('mousedown', function removeAccessibilityClass() {
+      document.body.classList.remove(ENABLE_ACCESSIBILITY_CLASS);
+    });
   }
 }
 
-export default setupAccessibility;
+export default attachAccessibilityEvents;

--- a/packages/core/src/global/js/accessibility.js
+++ b/packages/core/src/global/js/accessibility.js
@@ -1,0 +1,14 @@
+const ACCESSIBILITY_CLASS = 'js-ray-keyboard-nav';
+
+// Let the document know when the mouse is being used,
+// so accessibility styling can be removed.
+function addAccessibilityClass() {
+  document.body.classList.add(ACCESSIBILITY_CLASS);
+}
+
+function removeAccessibilityClass() {
+  document.body.classList.remove(ACCESSIBILITY_CLASS);
+}
+
+document.addEventListener('mousedown', removeAccessibilityClass);
+document.addEventListener('keydown', addAccessibilityClass);

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,8 +1,9 @@
 import './global/js/polyfills';
-import './global/js/accessibility';
+import setupAccessibility from './global/js/accessibility';
 import boot from './global/js/boot';
 
 boot();
+setupAccessibility();
 
 export * from './components';
 export { default as settings } from './global/js/settings';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,9 +1,9 @@
 import './global/js/polyfills';
-import setupAccessibility from './global/js/accessibility';
+import attachAccessibilityEvents from './global/js/accessibility';
 import boot from './global/js/boot';
 
 boot();
-setupAccessibility();
+attachAccessibilityEvents();
 
 export * from './components';
 export { default as settings } from './global/js/settings';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,4 +1,5 @@
 import './global/js/polyfills';
+import './global/js/accessibility';
 import boot from './global/js/boot';
 
 boot();

--- a/packages/core/test/global/accessibility.test.js
+++ b/packages/core/test/global/accessibility.test.js
@@ -7,10 +7,22 @@ describe('accessibility', () => {
 
   test('it works with SSR', () => {
     expect(() => {
-      const tempDocument = global.document;
-      global.document = undefined;
+      const spy = jest.spyOn(document, 'addEventListener');
+      const realDocument = global.document;
+
+      Object.defineProperty(global, 'document', {
+        value: undefined,
+        writable: true
+      });
+
       setupAccessibility();
-      global.document = tempDocument;
+
+      Object.defineProperty(global, 'document', {
+        value: realDocument,
+        writable: true
+      });
+
+      expect(spy).not.toHaveBeenCalled();
     }).not.toThrow();
   });
 
@@ -23,5 +35,17 @@ describe('accessibility', () => {
     document.dispatchEvent(keydownEvent);
 
     expect(document.body.classList.value).toMatch(/js-ray-keyboard-nav/);
+  });
+
+  test('should remove keyboard nav class to body', () => {
+    setupAccessibility();
+
+    document.body.classList.add('ray-js-keyboard-nav');
+    expect(document.body.classList.value).toMatch(/ray-js-keyboard-nav/);
+
+    const mouseEvent = new MouseEvent('mousedown');
+    document.dispatchEvent(mouseEvent);
+
+    expect(document.body.classList.value).not.toMatch(/js-ray-keyboard-nav/);
   });
 });

--- a/packages/core/test/global/accessibility.test.js
+++ b/packages/core/test/global/accessibility.test.js
@@ -5,7 +5,7 @@ describe('accessibility', () => {
     document.body.classList = null;
   });
 
-  test('it works with SSR', () => {
+  test('it works with server side rendering', () => {
     expect(() => {
       const spy = jest.spyOn(document, 'addEventListener');
       const realDocument = global.document;

--- a/packages/core/test/global/accessibility.test.js
+++ b/packages/core/test/global/accessibility.test.js
@@ -1,4 +1,4 @@
-import setupAccessibility from '../../src/global/js/accessibility';
+import attachAccessibilityEvents from '../../src/global/js/accessibility';
 
 describe('accessibility', () => {
   afterEach(() => {
@@ -15,7 +15,7 @@ describe('accessibility', () => {
         writable: true
       });
 
-      setupAccessibility();
+      attachAccessibilityEvents();
 
       Object.defineProperty(global, 'document', {
         value: realDocument,
@@ -27,18 +27,20 @@ describe('accessibility', () => {
   });
 
   test('should add keyboard nav class to body', () => {
-    setupAccessibility();
+    attachAccessibilityEvents();
 
     expect(document.body.classList.value).not.toMatch(/ray-js-keyboard-nav/);
 
     const keydownEvent = new KeyboardEvent('keydown');
     document.dispatchEvent(keydownEvent);
 
-    expect(document.body.classList.value).toMatch(/js-ray-keyboard-nav/);
+    expect(document.body.classList.value).toMatch(
+      /js-ray-enable-accessibility/
+    );
   });
 
   test('should remove keyboard nav class to body', () => {
-    setupAccessibility();
+    attachAccessibilityEvents();
 
     document.body.classList.add('ray-js-keyboard-nav');
     expect(document.body.classList.value).toMatch(/ray-js-keyboard-nav/);
@@ -46,6 +48,8 @@ describe('accessibility', () => {
     const mouseEvent = new MouseEvent('mousedown');
     document.dispatchEvent(mouseEvent);
 
-    expect(document.body.classList.value).not.toMatch(/js-ray-keyboard-nav/);
+    expect(document.body.classList.value).not.toMatch(
+      /js-ray-enable-accessibility/
+    );
   });
 });

--- a/packages/core/test/global/accessibility.test.js
+++ b/packages/core/test/global/accessibility.test.js
@@ -1,0 +1,27 @@
+import setupAccessibility from '../../src/global/js/accessibility';
+
+describe('accessibility', () => {
+  afterEach(() => {
+    document.body.classList = null;
+  });
+
+  test('it works with SSR', () => {
+    expect(() => {
+      const tempDocument = global.document;
+      global.document = undefined;
+      setupAccessibility();
+      global.document = tempDocument;
+    }).not.toThrow();
+  });
+
+  test('should add keyboard nav class to body', () => {
+    setupAccessibility();
+
+    expect(document.body.classList.value).not.toMatch(/ray-js-keyboard-nav/);
+
+    const keydownEvent = new KeyboardEvent('keydown');
+    document.dispatchEvent(keydownEvent);
+
+    expect(document.body.classList.value).toMatch(/js-ray-keyboard-nav/);
+  });
+});

--- a/packages/core/test/global/boot.test.js
+++ b/packages/core/test/global/boot.test.js
@@ -7,7 +7,7 @@ const {
 } = require('../../src/global/js/boot');
 
 describe('boot', () => {
-  test('it works with SSR', () => {
+  test('it works with server side rendering', () => {
     const realDocument = global.document;
     const realWindow = global.window;
 

--- a/packages/core/test/global/boot.test.js
+++ b/packages/core/test/global/boot.test.js
@@ -7,6 +7,39 @@ const {
 } = require('../../src/global/js/boot');
 
 describe('boot', () => {
+  test('it works with SSR', () => {
+    const realDocument = global.document;
+    const realWindow = global.window;
+
+    Object.defineProperty(global, 'document', {
+      value: undefined,
+      writable: true
+    });
+
+    expect(() => {
+      boot();
+    }).not.toThrow();
+
+    Object.defineProperty(global, 'window', {
+      value: undefined,
+      writable: true
+    });
+
+    expect(() => {
+      boot();
+    }).not.toThrow();
+
+    Object.defineProperty(global, 'document', {
+      value: realDocument,
+      writable: true
+    });
+
+    Object.defineProperty(global, 'window', {
+      value: realWindow,
+      writable: true
+    });
+  });
+
   test('it initailizes all components if DOM is ready', () => {
     Object.defineProperty(document, 'readyState', {
       value: 'complete',

--- a/packages/docs-app/src/data/navigation/navigation.json
+++ b/packages/docs-app/src/data/navigation/navigation.json
@@ -11,6 +11,9 @@
       "colors": {
         "title": "Colors"
       },
+      "accessibility": {
+        "title": "Accessibility"
+      },
       "fonts": {
         "title": "Fonts"
       },


### PR DESCRIPTION
Adds functionality that disables focus states and hover states for buttons when theyre not applicable. This makes the ux a little cleaner and is inline with peoples expectations for these states

## Before
![](https://cl.ly/b63e1c00a438/Screen%20Recording%202019-06-04%20at%2004.20%20PM.gif)

## After
![](https://cl.ly/916295a86644/Screen%20Recording%202019-06-04%20at%2004.16%20PM.gif)

![image](https://user-images.githubusercontent.com/6812331/58994688-5f5dd900-87bf-11e9-8bdd-3b34800a2a44.png)
 :^)