### PR TITLE
fix(breakpoints): add fix for 1px gap edge-case

### DIFF
--- a/packages/core/src/global/mixins/_breakpoints.scss
+++ b/packages/core/src/global/mixins/_breakpoints.scss
@@ -9,7 +9,7 @@
   @if map-has-key($ray-layout-grid-breakpoints, $minBreakpoint) {
     @if $maxBreakpoint {
       @if map-has-key($ray-layout-grid-breakpoints, $maxBreakpoint) {
-        @media (min-width: map-get($ray-layout-grid-breakpoints, $minBreakpoint)) and (max-width: map-get($ray-layout-grid-breakpoints, $maxBreakpoint) - 1) {
+        @media (min-width: map-get($ray-layout-grid-breakpoints, $minBreakpoint)) and (max-width: map-get($ray-layout-grid-breakpoints, $maxBreakpoint) - 0.5) {
           @content;
         }
       } @else {


### PR DESCRIPTION
Browser width can sometimes land on a half a pixel value. This typically happens when a user zooms in using their browser. 

## Repro example
https://codepen.io/adamraider/pen/MMKdeR


## Todo
- Add a comment in this file about the half pixel value
- Add a comment in the documentation about how best to use breakpoint values. We want to discourage people from making their own media queries, and caution them as to why