### PR TITLE
fix(form-item): ligatures on hints dont get cut off

### DIFF
--- a/packages/core/src/components/form-item/_form-item.scss
+++ b/packages/core/src/components/form-item/_form-item.scss
@@ -8,10 +8,10 @@
       display: block;
       color: $ray-color-text-medium;
       font-weight: 400;
-      font-size: $ray-field-label-size-focus;
+      font-size: 0.75rem;
       margin-top: 0.25rem;
       margin-left: $ray-field-h-spacing;
-      line-height: 1;
+      line-height: 1.25rem;
       width: 100%;
       text-overflow: ellipsis;
       overflow: hidden;

--- a/packages/core/src/components/form-item/_form-item.scss
+++ b/packages/core/src/components/form-item/_form-item.scss
@@ -9,7 +9,6 @@
       color: $ray-color-text-medium;
       font-weight: 400;
       font-size: 0.75rem;
-      margin-top: 0.25rem;
       margin-left: $ray-field-h-spacing;
       line-height: 1.25rem;
       width: 100%;


### PR DESCRIPTION
closes #151 

Repro on Chrome for Windows


# before
![image](https://user-images.githubusercontent.com/6812331/60448874-7b08a380-9bf4-11e9-9710-da26e34d1d7c.png)

# after
![image](https://user-images.githubusercontent.com/6812331/60448759-4399f700-9bf4-11e9-9343-44a0991ad678.png)
