### PR TITLE
fix(select): add space around arrow so doesn't overlap

### DIFF
--- a/packages/core/src/components/select/_select.scss
+++ b/packages/core/src/components/select/_select.scss
@@ -72,7 +72,7 @@
       font-size: $ray-field-label-size;
       display: block;
       background-color: transparent;
-      padding: 0 $ray-field-h-spacing;
+      padding: 0 1.75rem 0 $ray-field-h-spacing;
       outline: 0;
       border: 0;
       cursor: pointer;
@@ -80,6 +80,10 @@
 
       &::-ms-expand {
         display: none;
+      }
+
+      [dir='rtl'] & {
+        padding: 0 $ray-field-h-spacing 0 1.75rem;
       }
     }
 

--- a/packages/core/stories/select.stories.js
+++ b/packages/core/stories/select.stories.js
@@ -12,7 +12,7 @@ storiesOf('Select', module)
     setTimeout(init);
 
     return (
-      <div className="ray-select">
+      <div className="ray-select" style={{ width: '100px' }}>
         <select className="ray-select__input">
           <option value="" disabled selected data-ray-placeholder />
           <option value="Pikatchu">Pikatchu</option>

--- a/packages/core/stories/select.stories.js
+++ b/packages/core/stories/select.stories.js
@@ -62,6 +62,23 @@ storiesOf('Select', module)
       </div>
     );
   })
+  .add('select, with an overflowing value', () => {
+    setTimeout(init);
+
+    return (
+      <div className="ray-select" style={{ width: '100px' }}>
+        <select className="ray-select__input">
+          <option value="" disabled selected data-ray-placeholder />
+          <option value="Pikatchu">Pikatchu</option>
+          <option value="Squirtle">Squirtle</option>
+          <option value="Charmander">Charmander</option>
+        </select>
+        <label className="ray-select__label">
+          {"What's your favorite Pokémon?"}
+        </label>
+      </div>
+    );
+  })
   .add('select, required', () => {
     setTimeout(init);
 

--- a/packages/core/stories/select.stories.js
+++ b/packages/core/stories/select.stories.js
@@ -12,7 +12,7 @@ storiesOf('Select', module)
     setTimeout(init);
 
     return (
-      <div className="ray-select" style={{ width: '100px' }}>
+      <div className="ray-select">
         <select className="ray-select__input">
           <option value="" disabled selected data-ray-placeholder />
           <option value="Pikatchu">Pikatchu</option>


### PR DESCRIPTION
I don't think there is a way to do this with pure css to show an ellipsis. 

BEFORE:
![Screen Shot 2019-07-09 at 11 26 07 AM](https://user-images.githubusercontent.com/19141291/60902219-4375a900-a23d-11e9-966f-b8c2361553a1.png)


AFTER:
![Screen Shot 2019-07-09 at 11 25 51 AM](https://user-images.githubusercontent.com/19141291/60902227-46709980-a23d-11e9-9b85-20e6dd9e3154.png)
