### PR TITLE
fix(checkbox): squishing on small containers

### DIFF
--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -26,6 +26,7 @@
         background-color: $ray-color-white;
         border: $ray-radio-checkbox-border-width solid $ray-color-black;
         min-width: $ray-radio-checkbox-size;
+        width: $ray-radio-checkbox-size;
         height: $ray-radio-checkbox-size;
         position: relative;
         display: inline-block;

--- a/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
+++ b/packages/core/src/components/radio-checkbox/_radio-checkbox.scss
@@ -25,7 +25,7 @@
         content: '';
         background-color: $ray-color-white;
         border: $ray-radio-checkbox-border-width solid $ray-color-black;
-        width: $ray-radio-checkbox-size;
+        min-width: $ray-radio-checkbox-size;
         height: $ray-radio-checkbox-size;
         position: relative;
         display: inline-block;


### PR DESCRIPTION
BEFORE:
<img width="390" alt="Screen Shot 2019-07-10 at 5 06 07 PM" src="https://user-images.githubusercontent.com/19141291/61010697-5c698180-a345-11e9-9973-f495eed28493.png">


AFTER:
![Screen Shot 2019-07-10 at 7 04 45 PM](https://user-images.githubusercontent.com/19141291/61010759-9c306900-a345-11e9-932f-0f05652cb084.png)
