### PR TITLE
fix: add browser support to ray-core

### DIFF
--- a/packages/core/babel.config.js
+++ b/packages/core/babel.config.js
@@ -4,7 +4,8 @@ module.exports = {
       '@babel/preset-env',
       {
         targets: {
-          node: 'current'
+          node: 'current',
+          browsers: ['> 5%', 'Last 3 versions and not ie < 11']
         },
         ...(process.env.NODE_ENV === 'test'
           ? { modules: 'auto' }


### PR DESCRIPTION
specifically [`Event()` is not supported by IE ](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event#Browser_compatibility)

This is causing this error:
<img width="1539" alt="Screen Shot 2019-07-25 at 2 25 27 PM" src="https://user-images.githubusercontent.com/19141291/61898845-39fc6a00-aee8-11e9-960a-ca7552cb67ae.png">
