### PR TITLE
fix: IE11 issue

### DIFF
--- a/packages/core/src/components/select/index.js
+++ b/packages/core/src/components/select/index.js
@@ -66,7 +66,11 @@ class Select {
 
   set(value) {
     this._inputElement.value = value;
-    this._inputElement.dispatchEvent(new Event('change'));
+
+    // IE11 fix: can't use new Event()
+    const event = document.createEvent('HTMLEvents');
+    event.initEvent('change', true, true);
+    this._inputElement.dispatchEvent(event);
   }
 
   onFocus = () => {


### PR DESCRIPTION
babel doesn't transpile `new Event()` for IE11 :(

so let's do it ourselves using [`createEvent`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent) - tested in Browserstack IE11