### PR TITLE
fix: adds set method and change event for chip

### DIFF
--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -42,7 +42,7 @@ chip.destroy();
 | `Chip.createAll`         | `HTMLElement:Object` | create all instances in document      |
 | `Chip.create`            | `HTMLElement:Object` | create an instance                    |
 | `Chip.prototype.destroy` |                      | destroy the instance                  |
-| `Chip.prototype.set`     |                      | sets the active state of the instance |
+| `Chip.prototype.set`     | `Boolean`            | sets the active state of the instance |
 
 ## Modifiers
 

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -46,7 +46,7 @@ chip.destroy();
 
 ## Modifiers
 
-Use these modifiers with `.ray-select` class.
+Use these modifiers with `.ray-chip` class.
 
 | Selector            | Description                              |
 | ------------------- | ---------------------------------------- |

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -18,3 +18,36 @@ title: Chip
     variation="chip--with-icon"
     >
 </component>
+
+# JavaScript API
+
+```javascript
+import { Chip } from '@wework/ray-core';
+
+// instantiate all instances on document
+Chip.createAll();
+
+// create instance
+const chip = Chip.create(document.querySelector('.ray-chip'));
+
+// set the active state of the instance
+chip.set('false');
+
+// destroy
+chip.destroy();
+```
+
+| Method                   | Params               | Description                           |
+| ------------------------ | -------------------- | ------------------------------------- |
+| `Chip.createAll`         | `HTMLElement:Object` | create all instances in document      |
+| `Chip.create`            | `HTMLElement:Object` | create an instance                    |
+| `Chip.prototype.destroy` |                      | destroy the instance                  |
+| `Chip.prototype.set`     |                      | sets the active state of the instance |
+
+## Modifiers
+
+Use these modifiers with `.ray-select` class.
+
+| Selector            | Description                              |
+| ------------------- | ---------------------------------------- |
+| `.ray-chip--active` | Selector for applying active chip styles |

--- a/packages/core/src/components/chip/index.js
+++ b/packages/core/src/components/chip/index.js
@@ -57,12 +57,14 @@ class Chip {
   onClick = () => {
     this.state.active = !this.state.active;
     this.assignClasses();
+    this.emitChange();
   };
 
   onSpace = event => {
     if (event.code === 'Space' || event.key === ' ') {
       this.state.active = !this.state.active;
       this.assignClasses();
+      this.emitChange();
     }
   };
 
@@ -72,6 +74,17 @@ class Chip {
     this._root.removeEventListener('mousedown', this.onClick);
 
     this.constructor.instances.delete(this._root);
+  }
+
+  emitChange() {
+    const newEvent = document.createEvent('HTMLEvents');
+    newEvent.initEvent('change', true, true);
+    this._root.dispatchEvent(newEvent);
+  }
+
+  set(isActive) {
+    this.state.active = isActive;
+    this.assignClasses();
   }
 }
 

--- a/packages/core/src/components/chip/index.js
+++ b/packages/core/src/components/chip/index.js
@@ -85,6 +85,7 @@ class Chip {
   set(isActive) {
     this.state.active = isActive;
     this.assignClasses();
+    this.emitChange();
   }
 }
 

--- a/packages/core/test/components/chip.test.js
+++ b/packages/core/test/components/chip.test.js
@@ -78,4 +78,21 @@ describe('Chip', () => {
     expect(chipEl.classList).not.toContain('ray-chip--active');
     chip.destroy();
   });
+
+  test('it sets active to true', () => {
+    const { chip, chipEl } = setupTest();
+
+    chip.set(true);
+    expect(chipEl.classList).toContain('ray-chip--active');
+    chip.destroy();
+  });
+
+  test('it sets active to false', () => {
+    const { chip, chipEl } = setupTest();
+
+    triggerEvent(chipEl, 'mousedown');
+    chip.set(false);
+    expect(chipEl.classList).not.toContain('ray-chip--active');
+    chip.destroy();
+  });
 });


### PR DESCRIPTION
Emits a change event in `onClick` and `onSpace` so consumers can set event listeners for just the `change` event. Also adds a `set` method that allows consumers to set the active state of the chip