### PR TITLE
feat(core-react): add types for image

### DIFF
--- a/packages/core-react/index.d.ts
+++ b/packages/core-react/index.d.ts
@@ -93,14 +93,24 @@ export type SelectProps = {
 
 declare const Select: React.FC<SelectProps>;
 
-export { 
-  Button, 
+export type ImageProps = {
+  className?: string;
+  src: string;
+  aspect: '16by9' | '1by1' | '3by4' | '4by3' | 'cinema';
+  bg?: boolean;
+} & React.HTMLProps<HTMLImageElement>;
+
+declare const Image: React.FC<ImageProps>;
+
+export {
+  Button,
   Card,
   Checkbox,
-  Container, 
-  Grid, 
+  Container,
+  Grid,
+  Image,
   Radio,
   Select,
   TextArea,
-  TextField, 
+  TextField
 };


### PR DESCRIPTION
Adds typescript types for `Image` in `core-react`.