### PR TITLE
James/selectprops functionality

### DIFF
--- a/packages/core-react/index.d.ts
+++ b/packages/core-react/index.d.ts
@@ -80,6 +80,8 @@ export type CheckboxProps = {
 
 declare const Checkbox: React.FC<CheckboxProps>;
 
+declare type IconPositions = 'iconstart' | 'iconend';
+
 export type SelectProps = {
   className?: string;
   id?: string;
@@ -88,6 +90,11 @@ export type SelectProps = {
   compact?: boolean;
   disabled?: boolean;
   placeholder?: string;
+  prepend?: boolean,
+  icon?: React.ReactNode,
+  error?:boolean,
+  active?:boolean,
+  iconPosition?: IconPositions;
   children?: React.ReactNode;
 } & React.HTMLProps<HTMLSelectElement>;
 

--- a/packages/core-react/index.d.ts
+++ b/packages/core-react/index.d.ts
@@ -95,6 +95,7 @@ export type SelectProps = {
   error?:boolean,
   active?:boolean,
   iconPosition?: IconPositions;
+  onChange?:void;
   children?: React.ReactNode;
 } & React.HTMLProps<HTMLSelectElement>;
 

--- a/packages/core-react/index.d.ts
+++ b/packages/core-react/index.d.ts
@@ -95,7 +95,6 @@ export type SelectProps = {
   error?:boolean,
   active?:boolean,
   iconPosition?: IconPositions;
-  onChange?:void;
   children?: React.ReactNode;
 } & React.HTMLProps<HTMLSelectElement>;
 

--- a/packages/core-react/index.d.ts
+++ b/packages/core-react/index.d.ts
@@ -109,6 +109,13 @@ export type ImageProps = {
 
 declare const Image: React.FC<ImageProps>;
 
+export type IconProps = {
+  prepend?: boolean;
+  icon: React.ReactNode;
+} & React.HTMLProps<HTMLImageElement>;
+
+declare const Icon: React.FC<IconProps>;
+
 export {
   Button,
   Card,

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -16,7 +16,7 @@
   "author": "WeWork Companies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@wework/ray-core": "^1.4.0",
+    "@wework/ray-core": "^1.9.0",
     "clsx": "^1.0.4"
   },
   "repository": {

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -16,7 +16,7 @@
   "author": "WeWork Companies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@wework/ray-core": "^1.9.0",
+    "@wework/ray-core": "^1.4.0",
     "clsx": "^1.0.4"
   },
   "repository": {

--- a/packages/core-react/src/components/Common/Icon.js
+++ b/packages/core-react/src/components/Common/Icon.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Icon = ({ prepend, icon }) => {
+  if (prepend) {
+    return <div className="ray-select__prepend">{icon}</div>;
+  }
+  return <div>{icon}</div>;
+};
+
+export default Icon;
+
+Icon.propTypes = {
+  prepend: PropTypes.bool,
+  icon: PropTypes.node
+};

--- a/packages/core-react/src/components/Select/Select.scss
+++ b/packages/core-react/src/components/Select/Select.scss
@@ -1,0 +1,8 @@
+//overwriting ray componentdefault style -webkit-appearance: true
+.ray-select__input {
+  -webkit-appearance: none;
+}
+
+// [dir='rtl'] .ray-select__input {
+//   padding: -6px -6.75rem 0 !important;
+// }

--- a/packages/core-react/src/components/Select/Select.scss
+++ b/packages/core-react/src/components/Select/Select.scss
@@ -2,7 +2,3 @@
 .ray-select__input {
   -webkit-appearance: none;
 }
-
-// [dir='rtl'] .ray-select__input {
-//   padding: -6px -6.75rem 0 !important;
-// }

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -2,6 +2,13 @@ import React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
+export const InputIcon = ({ prepend, icon }) => {
+  if (prepend) {
+    return <div className="ray-select__prepend">{icon}</div>;
+  }
+  return <div>{icon}</div>;
+};
+
 export default function Select({
   className,
   id,
@@ -10,34 +17,80 @@ export default function Select({
   disabled,
   placeholder,
   label,
-  children
+  active = false,
+  error = false,
+  prepend = false,
+  iconPosition = 'iconstart',
+  icon,
+  value = '',
+  children,
+  ...rest
 }) {
-  return (
-    <div
-      className={clsx(
-        'ray-select',
-        {
-          'ray-select--compact': compact,
-          'ray-select--disabled': disabled
-        },
-        className
-      )}
-    >
-      <select
-        className="ray-select__input"
-        id={id}
-        name={name}
-        disabled={disabled}
-      >
-        <option value="" disabled selected data-ray-placeholder>
-          {placeholder}
-        </option>
-        {children}
-      </select>
+  const [activeClass, setActiveState] = React.useState(active);
+  const [currValue, setValue] = React.useState(value);
 
-      <label className="ray-select__label" htmlFor={id}>
-        {label}
-      </label>
+  const handleFocus = () => {
+    setActiveState(true);
+  };
+
+  const handleBlur = () => {
+    setActiveState(false);
+  };
+
+  const handleChange = event => {
+    setValue(event.target.value);
+  };
+
+  React.useEffect(() => {
+    if (value) {
+      setValue(value);
+    }
+  }, []);
+
+  const iconStart = iconPosition === 'iconstart';
+  const iconEnd = iconPosition === 'iconend';
+
+  return (
+    <div dir={iconStart ? '' : 'rtl'}>
+      <div className="ray-form-item">
+        <div
+          className={clsx(
+            'ray-select',
+            {
+              'ray-select--active': activeClass,
+              'ray-select--has-value': placeholder || currValue,
+              'ray-select--compact': compact,
+              'ray-select--disabled': disabled,
+              'ray-select--error': error,
+              'ray-select--with-prepend': prepend,
+              'ray-select--with-icon-start': iconStart,
+              'ray-select--with-icon-end': iconEnd
+            },
+            className
+          )}
+        >
+          <InputIcon icon={icon} prepend={prepend} />
+          <div className="ray-select__wrapper">
+            <select
+              className="ray-select__input"
+              name={name}
+              disabled={disabled}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              onFocus={handleFocus}
+              value={currValue}
+              {...rest}
+            >
+              <option disabled>{placeholder}</option>
+              {children}
+            </select>
+
+            <label className="ray-select__label" htmlFor={id}>
+              {label}
+            </label>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -50,5 +103,16 @@ Select.propTypes = {
   compact: PropTypes.bool,
   disabled: PropTypes.bool,
   placeholder: PropTypes.string,
-  children: PropTypes.node
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  value: PropTypes.number,
+  error: PropTypes.bool,
+  prepend: PropTypes.bool,
+  iconPosition: PropTypes.string,
+  icon: PropTypes.node
+};
+
+InputIcon.propTypes = {
+  prepend: PropTypes.bool,
+  icon: PropTypes.node
 };

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-
-export const InputIcon = ({ prepend, icon }) => {
-  if (prepend) {
-    return <div className="ray-select__prepend">{icon}</div>;
-  }
-  return <div>{icon}</div>;
-};
+import Icon from '../Common/Icon';
 
 export default function Select({
   className,
@@ -40,7 +34,9 @@ export default function Select({
 
   const handleChange = event => {
     setValue(event.target.value);
-    onChange(event);
+    if (onChange) {
+      onChange(event);
+    }
   };
 
   React.useEffect(() => {
@@ -76,7 +72,7 @@ export default function Select({
           className
         )}
       >
-        <InputIcon icon={icon} prepend={prepend} />
+        <Icon icon={icon} prepend={prepend} />
         <div className="ray-select__wrapper">
           <select
             className="ray-select__input"
@@ -85,10 +81,10 @@ export default function Select({
             onChange={handleChange}
             onBlur={handleBlur}
             onFocus={handleFocus}
-            value={currValue}
+            value={currValue || ''}
             {...rest}
           >
-            <option value="" disabled selected data-ray-placeholder>
+            <option value="" disabled data-ray-placeholder>
               {placeholder}
             </option>
             {children}
@@ -119,9 +115,4 @@ Select.propTypes = {
   iconPosition: PropTypes.oneOf(['iconstart', 'iconend']),
   icon: PropTypes.node,
   onChange: PropTypes.func
-};
-
-InputIcon.propTypes = {
-  prepend: PropTypes.bool,
-  icon: PropTypes.node
 };

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -19,6 +19,8 @@ export default function Select({
   value = '',
   children,
   onChange,
+  onFocus,
+  onBlur,
   ...rest
 }) {
   const [activeClass, setActiveState] = React.useState(active);
@@ -26,10 +28,16 @@ export default function Select({
 
   const handleFocus = () => {
     setActiveState(true);
+    if (onFocus) {
+      onFocus();
+    }
   };
 
   const handleBlur = () => {
     setActiveState(false);
+    if (onBlur) {
+      onBlur();
+    }
   };
 
   const handleChange = event => {
@@ -114,5 +122,14 @@ Select.propTypes = {
   prepend: PropTypes.bool,
   iconPosition: PropTypes.oneOf(['iconstart', 'iconend']),
   icon: PropTypes.node,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func
+};
+
+Select.defaultProps = {
+  active: false,
+  compact: false,
+  error: false,
+  prepend: false
 };

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -20,7 +20,7 @@ export default function Select({
   active = false,
   error = false,
   prepend = false,
-  iconPosition = 'iconstart',
+  iconPosition,
   icon,
   value = '',
   children,
@@ -46,11 +46,19 @@ export default function Select({
       setValue(value);
     }
   }, []);
+  let iconStart;
+  let iconEnd;
 
-  const iconStart = iconPosition === 'iconstart';
-  const iconEnd = iconPosition === 'iconend';
+  if (iconPosition) {
+    iconStart = iconPosition === 'iconstart';
+    iconEnd = iconPosition === 'iconend';
+  } else {
+    iconStart = false;
+    iconEnd = false;
+  }
+
   return (
-    <div dir={iconStart ? '' : 'rtl'}>
+    <div dir={iconEnd ? 'rtl' : ''}>
       <div
         className={clsx(
           'ray-select',
@@ -78,7 +86,9 @@ export default function Select({
             value={currValue}
             {...rest}
           >
-            <option disabled>{placeholder}</option>
+            <option value="" disabled selected data-ray-placeholder>
+              {placeholder}
+            </option>
             {children}
           </select>
 

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -108,7 +108,7 @@ Select.propTypes = {
   value: PropTypes.number,
   error: PropTypes.bool,
   prepend: PropTypes.bool,
-  iconPosition: PropTypes.string,
+  iconPosition: PropTypes.oneOf(['iconstart', 'iconend']),
   icon: PropTypes.node
 };
 

--- a/packages/core-react/src/components/Select/index.js
+++ b/packages/core-react/src/components/Select/index.js
@@ -24,6 +24,7 @@ export default function Select({
   icon,
   value = '',
   children,
+  onChange,
   ...rest
 }) {
   const [activeClass, setActiveState] = React.useState(active);
@@ -39,6 +40,7 @@ export default function Select({
 
   const handleChange = event => {
     setValue(event.target.value);
+    onChange(event);
   };
 
   React.useEffect(() => {
@@ -115,7 +117,8 @@ Select.propTypes = {
   error: PropTypes.bool,
   prepend: PropTypes.bool,
   iconPosition: PropTypes.oneOf(['iconstart', 'iconend']),
-  icon: PropTypes.node
+  icon: PropTypes.node,
+  onChange: PropTypes.func
 };
 
 InputIcon.propTypes = {

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -45,18 +45,18 @@ describe('Select', () => {
       expect(component.props().error).toEqual(true);
     });
 
-    it('has default "ICONSTART" property that can be set (:boolean)', () => {
+    it('has default "ICONSTART" property that can be set (:string)', () => {
       component.setProps({ iconPosition: 'iconstart' });
       expect(component.find('.ray-select--with-icon-start')).toHaveLength(1);
     });
 
-    it('has default "ICONEND" property that can be set (:any)', () => {
+    it('has default "ICONEND" property that can be set (:string)', () => {
       expect(component.find('.ray-select--with-icon-start')).toHaveLength(0);
       component.setProps({ iconPosition: 'iconend' });
       expect(component.find('.ray-select--with-icon-start')).toHaveLength(1);
     });
 
-    it('has default "ICONPREPEND" property that can be set (:any)', () => {
+    it('has default "prepend" property that can be set (:true)', () => {
       component.setProps({ prepend: true });
       expect(component.props().prepend).toEqual(true);
     });

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -63,6 +63,7 @@ describe('Select', () => {
 
     it('has value property that can be set (:number)', () => {
       component.setProps({ value: 4 });
+      // component.state(inputValue).toBe(4);
       expect(component.props().value).toEqual(4);
     });
   });
@@ -96,7 +97,8 @@ describe('Select', () => {
           <option value={4}>WeTech</option>
         </Select>
       );
-      component.find('select').prop('onFocus');
+
+      component.find('select').simulate('focus');
     });
   });
 });

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -62,7 +62,14 @@ describe('Select', () => {
     });
 
     it('has value property that can be set (:number)', () => {
-      component.setProps({ value: 4 });
+      component = mount(
+        <Select value={4}>
+          <option value={1}>WeWork</option>
+          <option value={2}>WeLive</option>
+          <option value={3}>WeGrow</option>
+          <option value={4}>WeTech</option>
+        </Select>
+      );
       expect(component.props().value).toEqual(4);
     });
   });

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -60,6 +60,11 @@ describe('Select', () => {
       component.setProps({ prepend: true });
       expect(component.props().prepend).toEqual(true);
     });
+
+    it('has value property that can be set (:number)', () => {
+      component.setProps({ value: 4 });
+      expect(component.props().value).toEqual(4);
+    });
   });
 
   describe('Classes & Composed Classes', () => {

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -1,9 +1,22 @@
 import React from 'react';
 import { mount } from 'enzyme';
-
 import Select from '.';
 
 describe('Select', () => {
+  const fauxCallback = jest.fn();
+  let component;
+
+  beforeEach(() => {
+    component = mount(
+      <Select>
+        <option value={1}>WeWork</option>
+        <option value={2}>WeLive</option>
+        <option value={3}>WeGrow</option>
+        <option value={4}>WeTech</option>
+      </Select>
+    );
+  });
+
   test('it renders a select', () => {
     const wrapper = mount(<Select>hello world</Select>);
     expect(wrapper.find('.ray-select').length).toBe(1);
@@ -14,5 +27,71 @@ describe('Select', () => {
       <Select className="some-custom-class" id="selecttest" label="henlo" />
     );
     expect(wrapper.find('.ray-select.some-custom-class').length).toBe(1);
+  });
+
+  describe('Default Properties', () => {
+    it('has default "ACTIVE" property that can be set (:boolean)', () => {
+      component.setProps({ active: true });
+      expect(component.props().active).toEqual(true);
+    });
+
+    it('has default "COMPACT" property that can be set (:boolean)', () => {
+      component.setProps({ compact: true });
+      expect(component.props().compact).toEqual(true);
+    });
+
+    it('has default "ERROR" property that can be set (:boolean)', () => {
+      component.setProps({ error: true });
+      expect(component.props().error).toEqual(true);
+    });
+
+    it('has default "ICONSTART" property that can be set (:boolean)', () => {
+      component.setProps({ iconPosition: 'iconstart' });
+      expect(component.find('.ray-select--with-icon-start')).toHaveLength(1);
+    });
+
+    it('has default "ICONEND" property that can be set (:any)', () => {
+      expect(component.find('.ray-select--with-icon-start')).toHaveLength(0);
+      component.setProps({ iconPosition: 'iconend' });
+      expect(component.find('.ray-select--with-icon-start')).toHaveLength(1);
+    });
+
+    it('has default "ICONPREPEND" property that can be set (:any)', () => {
+      component.setProps({ prepend: true });
+      expect(component.props().prepend).toEqual(true);
+    });
+  });
+
+  describe('Classes & Composed Classes', () => {
+    it('contains DEFAULT', () => {
+      expect(component.find('.ray-select')).toHaveLength(1);
+      expect(component.find('.ray-select__wrapper')).toHaveLength(1);
+      expect(component.find('select').hasClass('ray-select__input')).toEqual(
+        true
+      );
+      expect(component.find('label').hasClass('ray-select__label')).toEqual(
+        true
+      );
+    });
+
+    it('contains specific class if select is in focus/blur (aka "active"/"inactive")', () => {
+      expect(component.find('.ray-select--active')).toHaveLength(0);
+      component.find('select').simulate('focus');
+      expect(component.find('.ray-select--active')).toHaveLength(1);
+    });
+  });
+
+  describe('Functions', () => {
+    it('onFocus', () => {
+      component = mount(
+        <Select onFocus={fauxCallback}>
+          <option value={1}>WeWork</option>
+          <option value={2}>WeLive</option>
+          <option value={3}>WeGrow</option>
+          <option value={4}>WeTech</option>
+        </Select>
+      );
+      component.find('select').prop('onFocus');
+    });
   });
 });

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -63,7 +63,6 @@ describe('Select', () => {
 
     it('has value property that can be set (:number)', () => {
       component.setProps({ value: 4 });
-      // component.state(inputValue).toBe(4);
       expect(component.props().value).toEqual(4);
     });
   });
@@ -87,7 +86,7 @@ describe('Select', () => {
     });
   });
 
-  describe('Functions', () => {
+  describe('Functions events', () => {
     it('onFocus', () => {
       component = mount(
         <Select onFocus={fauxCallback}>
@@ -97,8 +96,31 @@ describe('Select', () => {
           <option value={4}>WeTech</option>
         </Select>
       );
-
       component.find('select').simulate('focus');
+    });
+
+    it('onBlur', () => {
+      component = mount(
+        <Select onFocus={fauxCallback}>
+          <option value={1}>WeWork</option>
+          <option value={2}>WeLive</option>
+          <option value={3}>WeGrow</option>
+          <option value={4}>WeTech</option>
+        </Select>
+      );
+      component.find('select').simulate('blur');
+    });
+
+    it('onChange', () => {
+      component = mount(
+        <Select onFocus={fauxCallback}>
+          <option value={1}>WeWork</option>
+          <option value={2}>WeLive</option>
+          <option value={3}>WeGrow</option>
+          <option value={4}>WeTech</option>
+        </Select>
+      );
+      component.find('select').simulate('change');
     });
   });
 });

--- a/packages/core-react/src/components/Select/select.test.js
+++ b/packages/core-react/src/components/Select/select.test.js
@@ -101,7 +101,7 @@ describe('Select', () => {
 
     it('onBlur', () => {
       component = mount(
-        <Select onFocus={fauxCallback}>
+        <Select onBlur={fauxCallback}>
           <option value={1}>WeWork</option>
           <option value={2}>WeLive</option>
           <option value={3}>WeGrow</option>
@@ -113,7 +113,7 @@ describe('Select', () => {
 
     it('onChange', () => {
       component = mount(
-        <Select onFocus={fauxCallback}>
+        <Select onChange={fauxCallback}>
           <option value={1}>WeWork</option>
           <option value={2}>WeLive</option>
           <option value={3}>WeGrow</option>

--- a/packages/core-react/src/index.js
+++ b/packages/core-react/src/index.js
@@ -7,5 +7,5 @@ export { default as Select } from './components/Select';
 export { default as TextField } from './components/TextField';
 export { default as TextArea } from './components/TextArea';
 export { default as Type } from './components/Type';
-
+export { default as Icon } from './components/Common/Icon';
 export * from './components/Grid';

--- a/packages/core-react/stories/select.stories.js
+++ b/packages/core-react/stories/select.stories.js
@@ -1,12 +1,100 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-
 import Select from '../src/components/Select';
+import '../src/components/Select/Select.scss';
 
-storiesOf('Select', module).add('default', () => (
-  <Select id="select-test" label="henlo">
-    <option value="1">1</option>
-    <option value="2">2</option>
-    <option value="3">3</option>
-  </Select>
-));
+storiesOf('Select', module)
+  .add('default', () => {
+    return (
+      <Select id="select-test" compact={true} label="henlo">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+      </Select>
+    );
+  })
+  .add('select w/ error', () => (
+    <Select label="name" error={true} value={1}>
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </Select>
+  ))
+  .add('select w/ icon start', () => (
+    <Select
+      label="name"
+      iconPosition={'iconstart'}
+      icon={
+        <svg className="ray-select__icon--start" viewBox="0 0 25 25">
+          <g id="budicon-profile-picture">
+            <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+          </g>
+        </svg>
+      }
+    >
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </Select>
+  ))
+  .add('select w/ icon end', () => (
+    <Select
+      label="name"
+      iconPosition={'iconend'}
+      icon={
+        <svg className="ray-select__icon--start" viewBox="0 0 25 25">
+          <g id="budicon-profile-picture">
+            <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+          </g>
+        </svg>
+      }
+    >
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </Select>
+  ))
+  .add('select w/ icon prepend', () => (
+    <Select
+      label="name"
+      prepend={true}
+      iconPosition={'iconstart'}
+      icon={
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 25 25"
+          style={{ height: '1rem' }}
+        >
+          <g id="budicon-profile-picture">
+            <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+          </g>
+        </svg>
+      }
+    >
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </Select>
+  ))
+  .add('select w/ icon end prepend', () => (
+    <Select
+      label="name"
+      prepend={true}
+      iconPosition={'iconend'}
+      icon={
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 25 25"
+          style={{ height: '1rem' }}
+        >
+          <g id="budicon-profile-picture">
+            <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+          </g>
+        </svg>
+      }
+    >
+      <option value="1">1</option>
+      <option value="2">2</option>
+      <option value="3">3</option>
+    </Select>
+  ));

--- a/packages/core-react/stories/select.stories.js
+++ b/packages/core-react/stories/select.stories.js
@@ -7,26 +7,43 @@ storiesOf('Select', module)
   .add('default', () => {
     return (
       <Select id="select-test" label="henlo">
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
+        <option value={1}>WeWork</option>
+        <option value={2}>WeLive</option>
+        <option value={3}>WeGrow</option>
+        <option value={4}>WeTech</option>
+      </Select>
+    );
+  })
+  .add('default w/ placeholder', () => {
+    return (
+      <Select
+        id="select-test"
+        label="henlo"
+        placeholder="Please select a value"
+      >
+        <option value="1">WeWork</option>
+        <option value="2">WeLive</option>
+        <option value="3">WeGrow</option>
+        <option value="4">WeTech</option>
       </Select>
     );
   })
   .add('compact', () => {
     return (
       <Select id="select-test" compact={true} label="henlo">
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
+        <option value={1}>WeWork</option>
+        <option value={2}>WeLive</option>
+        <option value={3}>WeGrow</option>
+        <option value={4}>WeTech</option>
       </Select>
     );
   })
   .add('select w/ error', () => (
     <Select label="name" error={true} value={1}>
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value={1}>WeWork</option>
+      <option value={2}>WeLive</option>
+      <option value={3}>WeGrow</option>
+      <option value={4}>WeTech</option>
     </Select>
   ))
   .add('select w/ icon start', () => (
@@ -41,9 +58,10 @@ storiesOf('Select', module)
         </svg>
       }
     >
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value={1}>WeWork</option>
+      <option value={2}>WeLive</option>
+      <option value={3}>WeGrow</option>
+      <option value={4}>WeTech</option>
     </Select>
   ))
   .add('select w/ icon end', () => (
@@ -58,9 +76,10 @@ storiesOf('Select', module)
         </svg>
       }
     >
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value={1}>WeWork</option>
+      <option value={2}>WeLive</option>
+      <option value={3}>WeGrow</option>
+      <option value={4}>WeTech</option>
     </Select>
   ))
   .add('select w/ icon prepend', () => (
@@ -80,9 +99,10 @@ storiesOf('Select', module)
         </svg>
       }
     >
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value={1}>WeWork</option>
+      <option value={2}>WeLive</option>
+      <option value={3}>WeGrow</option>
+      <option value={4}>WeTech</option>
     </Select>
   ))
   .add('select w/ icon end prepend', () => (
@@ -102,8 +122,9 @@ storiesOf('Select', module)
         </svg>
       }
     >
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
+      <option value={1}>WeWork</option>
+      <option value={2}>WeLive</option>
+      <option value={3}>WeGrow</option>
+      <option value={4}>WeTech</option>
     </Select>
   ));

--- a/packages/core-react/stories/select.stories.js
+++ b/packages/core-react/stories/select.stories.js
@@ -23,7 +23,7 @@ storiesOf('Select', module)
   .add('select w/ icon start', () => (
     <Select
       label="name"
-      iconPosition={'iconstart'}
+      iconPosition="iconstart"
       icon={
         <svg className="ray-select__icon--start" viewBox="0 0 25 25">
           <g id="budicon-profile-picture">
@@ -40,7 +40,7 @@ storiesOf('Select', module)
   .add('select w/ icon end', () => (
     <Select
       label="name"
-      iconPosition={'iconend'}
+      iconPosition="iconend"
       icon={
         <svg className="ray-select__icon--start" viewBox="0 0 25 25">
           <g id="budicon-profile-picture">
@@ -58,7 +58,7 @@ storiesOf('Select', module)
     <Select
       label="name"
       prepend={true}
-      iconPosition={'iconstart'}
+      iconPosition="iconstart"
       icon={
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -80,7 +80,7 @@ storiesOf('Select', module)
     <Select
       label="name"
       prepend={true}
-      iconPosition={'iconend'}
+      iconPosition="iconend"
       icon={
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
**Ray Component**: https://ray.wework.com/components/select/

How to run locally
$ yarn storybook
$ yarn test core-components --watch

Nutshell Details:
Semantic wrapper around Select  element:

`<Select />`

<img width="893" alt="Screen Shot 2019-07-30 at 9 02 36 PM" src="https://user-images.githubusercontent.com/45638740/62176105-3c0e6080-b30e-11e9-8959-3668a87d65c6.png">
<img width="908" alt="Screen Shot 2019-07-30 at 9 02 45 PM" src="https://user-images.githubusercontent.com/45638740/62176113-43ce0500-b30e-11e9-8fb6-04995b660a7e.png">
<img width="959" alt="Screen Shot 2019-07-30 at 9 02 56 PM" src="https://user-images.githubusercontent.com/45638740/62176126-51838a80-b30e-11e9-8481-b0777d14d085.png">
<img width="920" alt="Screen Shot 2019-07-30 at 9 03 08 PM" src="https://user-images.githubusercontent.com/45638740/62176135-59432f00-b30e-11e9-962a-924ea06a1b85.png">