### PR TITLE
James/textbox props functionality

### DIFF
--- a/packages/core-react/src/components/TextField/index.js
+++ b/packages/core-react/src/components/TextField/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-// import Icon from '../Common/Icon';
+import Icon from '../Common/Icon';
 
 export default function TextField({
   id,
@@ -18,29 +18,40 @@ export default function TextField({
   onFocus,
   onBlur,
   onKeyUp,
+  onChange,
   hint,
   hintSuccess,
   hintError,
   className,
-  iconStart,
-  iconEnd,
+  iconPosition,
+  icon,
   prepend,
   ...rest
 }) {
   const [inputValue, setInputValue] = React.useState(value);
   const [activeClass, setActiveState] = React.useState(active);
 
+  let iconStart;
+  let iconEnd;
+
+  if (iconPosition) {
+    iconStart = iconPosition === 'iconstart';
+    iconEnd = iconPosition === 'iconend';
+  } else {
+    iconStart = false;
+    iconEnd = false;
+  }
+
   const wrapperClass = clsx(
     'ray-text-field',
     {
-      'ray-text-field--has-value': value,
+      'ray-text-field--has-value': inputValue,
       'ray-text-field--error': error,
       'ray-text-field--success': success,
       'ray-text-field--disabled': disabled,
       'ray-text-field--required': required,
       'ray-text-field--compact': compact,
-      'ray-text-field--with-icon-start': iconStart,
-      'ray-text-field--with-icon-end': iconEnd,
+      'ray-text-field--with-icon-start': iconStart || iconEnd,
       'ray-text-field--with-prepend': prepend
     },
     className
@@ -65,28 +76,40 @@ export default function TextField({
     setActiveState(textvalue);
   };
 
+  const handleChange = event => {
+    setInputValue(event.target.value);
+    if (onChange) {
+      onChange(event);
+    }
+  };
+
   return (
     <div>
-      <div className={wrapperClass}>
-        {/* <Icon icon={icon} prepend={prepend} /> */}
-        <div className="ray-text-field__wrapper">
-          <input
-            className="ray-text-field__input"
-            id={id}
-            type={type}
-            value={inputValue}
-            placeholder={placeholder}
-            disabled={disabled}
-            onFocus={onFocusAction(!activeClass)}
-            onBlur={onBlurAction(!activeClass)}
-            onKeyUp={onKeyUpAction()}
-            {...rest}
-          />
-          {label && (
-            <label className="ray-text-field__label" htmlFor={id}>
-              {label}
-            </label>
-          )}
+      <div dir={iconEnd ? 'rtl' : ''}>
+        <div className="ray-form-item">
+          <div className={wrapperClass}>
+            <Icon icon={icon} prepend={prepend} />
+            <div className="ray-text-field__wrapper">
+              <input
+                className="ray-text-field__input"
+                id={id}
+                type={type}
+                value={inputValue || ''}
+                placeholder={placeholder}
+                disabled={disabled}
+                onFocus={onFocusAction(!activeClass)}
+                onBlur={onBlurAction(!activeClass)}
+                onKeyUp={onKeyUpAction()}
+                onChange={handleChange}
+                {...rest}
+              />
+              {label && (
+                <label className="ray-text-field__label" htmlFor={id}>
+                  {label}
+                </label>
+              )}
+            </div>
+          </div>
         </div>
       </div>
       <div
@@ -119,12 +142,13 @@ TextField.propTypes = {
   onFocus: PropTypes.func,
   onKeyUp: PropTypes.func,
   onBlur: PropTypes.func,
+  onChange: PropTypes.func,
   hint: PropTypes.string,
   hintSuccess: PropTypes.string,
   hintError: PropTypes.string,
   prepend: PropTypes.bool,
-  iconStart: PropTypes.bool,
-  iconEnd: PropTypes.bool
+  iconPosition: PropTypes.oneOf(['iconstart', 'iconend']),
+  icon: PropTypes.node
 };
 
 TextField.defaultProps = {

--- a/packages/core-react/src/components/TextField/index.js
+++ b/packages/core-react/src/components/TextField/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+// import Icon from '../Common/Icon';
 
 export default function TextField({
   id,
@@ -13,9 +14,20 @@ export default function TextField({
   success,
   compact,
   label,
+  active,
+  onFocus,
+  onBlur,
+  onKeyUp,
+  hint,
+  iconPrepend,
+  hintSuccess,
+  hintError,
   className,
   ...rest
 }) {
+  const [inputValue, setInputValue] = React.useState(value);
+  const [activeClass, setActiveState] = React.useState(active);
+
   const wrapperClass = clsx(
     'ray-text-field',
     {
@@ -29,22 +41,59 @@ export default function TextField({
     className
   );
 
+  const onKeyUpAction = () => event => {
+    if (onKeyUp) {
+      onKeyUp();
+    }
+    setInputValue(event.target.value);
+  };
+  const onFocusAction = () => textvalue => {
+    if (onFocus) {
+      onFocus();
+    }
+    setActiveState(textvalue);
+  };
+  const onBlurAction = () => textvalue => {
+    if (onBlur) {
+      onBlur();
+    }
+    setActiveState(textvalue);
+  };
+
   return (
-    <div className={wrapperClass}>
-      <input
-        className="ray-text-field__input"
-        id={id}
-        type={type}
-        value={value}
-        placeholder={placeholder}
-        disabled={disabled}
-        {...rest}
-      />
-      {label && (
-        <label className="ray-text-field__label" htmlFor={id}>
-          {label}
-        </label>
-      )}
+    <div>
+      <div className={wrapperClass}>
+        {/* <Icon icon={icon} prepend={prepend} /> */}
+        <div className="ray-text-field__wrapper">
+          <input
+            className="ray-text-field__input"
+            id={id}
+            type={type}
+            value={inputValue}
+            placeholder={placeholder}
+            disabled={disabled}
+            onFocus={onFocusAction(!activeClass)}
+            onBlur={onBlurAction(!activeClass)}
+            onKeyUp={onKeyUpAction()}
+            {...rest}
+          />
+          {label && (
+            <label className="ray-text-field__label" htmlFor={id}>
+              {label}
+            </label>
+          )}
+        </div>
+      </div>
+      <div
+        className={clsx(
+          'ray-form-item__hint',
+          { 'ray-form-item__hint': hint },
+          { 'ray-form-item__hint--success': hintSuccess },
+          { 'ray-form-item__hint--error': hintError }
+        )}
+      >
+        {hint || (hintSuccess || hintError)}
+      </div>
     </div>
   );
 }
@@ -60,9 +109,26 @@ TextField.propTypes = {
   compact: PropTypes.bool,
   value: PropTypes.string,
   label: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  active: PropTypes.bool,
+  onFocus: PropTypes.func,
+  onKeyUp: PropTypes.func,
+  onBlur: PropTypes.func,
+  hint: PropTypes.string,
+  hintSuccess: PropTypes.string,
+  hintError: PropTypes.string,
+  iconPrepend: PropTypes.bool
 };
 
 TextField.defaultProps = {
-  type: 'text'
+  active: false,
+  type: 'text',
+  compact: false,
+  disabled: false,
+  error: false,
+  hint: '',
+  hintError: '',
+  hintSuccess: '',
+  iconPrepend: false,
+  success: false
 };

--- a/packages/core-react/src/components/TextField/index.js
+++ b/packages/core-react/src/components/TextField/index.js
@@ -45,7 +45,7 @@ export default function TextField({
   const wrapperClass = clsx(
     'ray-text-field',
     {
-      'ray-text-field--has-value': inputValue,
+      'ray-text-field--has-value': placeholder || inputValue,
       'ray-text-field--error': error,
       'ray-text-field--success': success,
       'ray-text-field--disabled': disabled,

--- a/packages/core-react/src/components/TextField/index.js
+++ b/packages/core-react/src/components/TextField/index.js
@@ -19,10 +19,12 @@ export default function TextField({
   onBlur,
   onKeyUp,
   hint,
-  iconPrepend,
   hintSuccess,
   hintError,
   className,
+  iconStart,
+  iconEnd,
+  prepend,
   ...rest
 }) {
   const [inputValue, setInputValue] = React.useState(value);
@@ -36,7 +38,10 @@ export default function TextField({
       'ray-text-field--success': success,
       'ray-text-field--disabled': disabled,
       'ray-text-field--required': required,
-      'ray-text-field--compact': compact
+      'ray-text-field--compact': compact,
+      'ray-text-field--with-icon-start': iconStart,
+      'ray-text-field--with-icon-end': iconEnd,
+      'ray-text-field--with-prepend': prepend
     },
     className
   );
@@ -117,7 +122,9 @@ TextField.propTypes = {
   hint: PropTypes.string,
   hintSuccess: PropTypes.string,
   hintError: PropTypes.string,
-  iconPrepend: PropTypes.bool
+  prepend: PropTypes.bool,
+  iconStart: PropTypes.bool,
+  iconEnd: PropTypes.bool
 };
 
 TextField.defaultProps = {
@@ -129,6 +136,6 @@ TextField.defaultProps = {
   hint: '',
   hintError: '',
   hintSuccess: '',
-  iconPrepend: false,
+  prepend: false,
   success: false
 };

--- a/packages/core-react/src/components/TextField/textField.test.js
+++ b/packages/core-react/src/components/TextField/textField.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import TextField from '.';
 
 describe('TextField', () => {
-  // const fauxCallback = jest.fn();
+  const fauxCallback = jest.fn();
   let component = '';
 
   beforeEach(() => {
@@ -44,22 +44,48 @@ describe('TextField', () => {
       expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
         0
       );
-      component.setProps({ iconStart: true });
+      component.setProps({ iconPosition: 'iconstart' });
       expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
         1
       );
     });
 
     it('has default "ICONEND" property that can be set (:boolean)', () => {
-      expect(component.find('.ray-text-field--with-icon-end')).toHaveLength(0);
-      component.setProps({ iconEnd: true });
-      expect(component.find('.ray-text-field--with-icon-end')).toHaveLength(1);
+      expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
+        0
+      );
+      component.setProps({ iconPosition: 'iconend' });
+      expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
+        1
+      );
     });
 
     it('has default "ICONPREPEND" property that can be set (:boolean)', () => {
       expect(component.props().prepend).toEqual(false);
       component.setProps({ prepend: true });
       expect(component.props().prepend).toEqual(true);
+    });
+  });
+
+  describe('Functions events', () => {
+    it('onFocus', () => {
+      component = mount(<TextField id="name" onFocus={fauxCallback} />);
+      component.find('input').simulate('focus');
+    });
+
+    it('onBlur', () => {
+      component = mount(<TextField id="name" onBlur={fauxCallback} />);
+      component.find('input').simulate('blur');
+    });
+
+    it('onKeyUp', () => {
+      component = mount(<TextField id="name" onKeyUp={fauxCallback} />);
+      component.find('input').simulate('keyup');
+    });
+
+    it('onChange', () => {
+      component = mount(<TextField id="name" onChange={fauxCallback} />);
+      component.find('input').simulate('change');
     });
   });
 });

--- a/packages/core-react/src/components/TextField/textField.test.js
+++ b/packages/core-react/src/components/TextField/textField.test.js
@@ -39,5 +39,27 @@ describe('TextField', () => {
       component.setProps({ hintError: 'This is a red hint.' });
       expect(component.props().hintError).toEqual('This is a red hint.');
     });
+
+    it('has default "ICONSTART" property that can be set (:boolean)', () => {
+      expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
+        0
+      );
+      component.setProps({ iconStart: true });
+      expect(component.find('.ray-text-field--with-icon-start')).toHaveLength(
+        1
+      );
+    });
+
+    it('has default "ICONEND" property that can be set (:boolean)', () => {
+      expect(component.find('.ray-text-field--with-icon-end')).toHaveLength(0);
+      component.setProps({ iconEnd: true });
+      expect(component.find('.ray-text-field--with-icon-end')).toHaveLength(1);
+    });
+
+    it('has default "ICONPREPEND" property that can be set (:boolean)', () => {
+      expect(component.props().prepend).toEqual(false);
+      component.setProps({ prepend: true });
+      expect(component.props().prepend).toEqual(true);
+    });
   });
 });

--- a/packages/core-react/src/components/TextField/textField.test.js
+++ b/packages/core-react/src/components/TextField/textField.test.js
@@ -4,6 +4,13 @@ import { mount } from 'enzyme';
 import TextField from '.';
 
 describe('TextField', () => {
+  // const fauxCallback = jest.fn();
+  let component = '';
+
+  beforeEach(() => {
+    component = mount(<TextField id="email" />);
+  });
+
   test('it renders a text field', () => {
     const wrapper = mount(<TextField id="email" />);
     expect(wrapper.find('input[type="text"]').length).toBe(1);
@@ -12,5 +19,25 @@ describe('TextField', () => {
   test('it renders a text field with a label', () => {
     const wrapper = mount(<TextField id="email" label="email address" />);
     expect(wrapper.find('label').length).toBe(1);
+  });
+
+  describe('Default Properties', () => {
+    it('has default "HINT" property that can be set (:string)', () => {
+      expect(component.props().hint).toEqual('');
+      component.setProps({ hint: 'This is a regular hint.' });
+      expect(component.props().hint).toEqual('This is a regular hint.');
+    });
+
+    it('has default "HINTSUCCESS" property that can be set (:string)', () => {
+      expect(component.props().hintSuccess).toEqual('');
+      component.setProps({ hintSuccess: 'This is a green hint.' });
+      expect(component.props().hintSuccess).toEqual('This is a green hint.');
+    });
+
+    it('has default "HINTERROR" property that can be set (:string)', () => {
+      expect(component.props().hintError).toEqual('');
+      component.setProps({ hintError: 'This is a red hint.' });
+      expect(component.props().hintError).toEqual('This is a red hint.');
+    });
   });
 });

--- a/packages/core-react/stories/TextField.stories.js
+++ b/packages/core-react/stories/TextField.stories.js
@@ -26,7 +26,7 @@ storiesOf('TextField', module)
   .add('compact', () => (
     <TextField id="example" value="worlds" placeholder="hello" compact />
   ))
-  .add('Email Input w/ Hint', () => {
+  .add('Input w/ Hint', () => {
     return (
       <TextField
         label="Email Address"
@@ -37,7 +37,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('Email Input w/ Hint Error', () => {
+  .add('TextField w/ Hint Error', () => {
     return (
       <TextField
         label="Email Address"
@@ -48,7 +48,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('Email Input w/ Hint Success', () => {
+  .add('TextField w/ Hint Success', () => {
     return (
       <TextField
         label="Email Address"
@@ -59,7 +59,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('Text Input w/ Icon Start', () => {
+  .add('TextField w/ Icon Start', () => {
     return (
       <TextField
         label="Email Address"
@@ -77,7 +77,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('Text Input w/ Icon End', () => {
+  .add('TextField w/ Icon End', () => {
     return (
       <TextField
         label="Email Address"
@@ -95,14 +95,14 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('Text Input w/ Icon Start w/ Prepend', () => {
+  .add('TextField w/ Icon Start w/ Prepend', () => {
     return (
       <TextField
         label="Email Address"
         id="unique456"
         type="email"
         placeholder="arya.stark@winterfell.org"
-        // iconPrepend={true}
+        // prepend={true}
         icon={
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/core-react/stories/TextField.stories.js
+++ b/packages/core-react/stories/TextField.stories.js
@@ -3,9 +3,7 @@ import { storiesOf } from '@storybook/react';
 import TextField from '../src/components/TextField';
 
 storiesOf('TextField', module)
-  .add('default', () => (
-    <TextField id="example" value={undefined} placeholder="hello" />
-  ))
+  .add('default', () => <TextField id="example" placeholder="hello" />)
   .add('required', () => (
     <TextField id="example" value={undefined} placeholder="hello" required />
   ))
@@ -37,7 +35,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('TextField w/ Hint Error', () => {
+  .add('w/ Hint Error', () => {
     return (
       <TextField
         label="Email Address"
@@ -48,7 +46,7 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('TextField w/ Hint Success', () => {
+  .add('w/ Hint Success', () => {
     return (
       <TextField
         label="Email Address"
@@ -59,14 +57,14 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('TextField w/ Icon Start', () => {
+  .add('w/ Icon Start', () => {
     return (
       <TextField
         label="Email Address"
         id="unique456"
         type="email"
         placeholder="arya.stark@winterfell.org"
-        // iconStart={true}
+        iconPosition="iconstart"
         icon={
           <svg className="ray-text-field__icon--start" viewBox="0 0 25 25">
             <g id="budicon-profile-picture">
@@ -77,16 +75,16 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('TextField w/ Icon End', () => {
+  .add('w/ Icon End', () => {
     return (
       <TextField
         label="Email Address"
         id="unique456"
         type="email"
         placeholder="arya.stark@winterfell.org"
-        // iconEnd={true}
+        iconPosition="iconend"
         icon={
-          <svg className="ray-text-field__icon--end" viewBox="0 0 25 25">
+          <svg className="ray-text-field__icon--start" viewBox="0 0 25 25">
             <g id="budicon-profile-picture">
               <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
             </g>
@@ -95,14 +93,38 @@ storiesOf('TextField', module)
       />
     );
   })
-  .add('TextField w/ Icon Start w/ Prepend', () => {
+  .add('w/ Icon Start w/ Prepend', () => {
     return (
       <TextField
         label="Email Address"
         id="unique456"
         type="email"
         placeholder="arya.stark@winterfell.org"
-        // prepend={true}
+        prepend={true}
+        iconPosition="iconstart"
+        icon={
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 25 25"
+            style={{ height: '1rem' }}
+          >
+            <g id="budicon-profile-picture">
+              <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+            </g>
+          </svg>
+        }
+      />
+    );
+  })
+  .add('w/ Icon End w/ Prepend', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        prepend={true}
+        iconPosition="iconend"
         icon={
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/core-react/stories/TextField.stories.js
+++ b/packages/core-react/stories/TextField.stories.js
@@ -5,18 +5,22 @@ import TextField from '../src/components/TextField';
 storiesOf('TextField', module)
   .add('default', () => <TextField id="example" placeholder="hello" />)
   .add('required', () => (
-    <TextField id="example" value={undefined} placeholder="hello" required />
+    <TextField id="example" value={undefined} label="hello hello" required />
+  ))
+  .add('placeholder', () => (
+    <TextField id="example" value={undefined} placeholder="hello wework" />
   ))
   .add('error', () => (
     <TextField
       id="example"
       value={undefined}
       placeholder="hello"
+      label="error"
       error="something went wrong"
     />
   ))
   .add('with value', () => (
-    <TextField id="example" value="worlds" placeholder="hello" />
+    <TextField id="example" placeholder="hello" value="9999999" />
   ))
   .add('disabled', () => (
     <TextField id="example" value="worlds" placeholder="hello" disabled />

--- a/packages/core-react/stories/TextField.stories.js
+++ b/packages/core-react/stories/TextField.stories.js
@@ -25,4 +25,95 @@ storiesOf('TextField', module)
   ))
   .add('compact', () => (
     <TextField id="example" value="worlds" placeholder="hello" compact />
-  ));
+  ))
+  .add('Email Input w/ Hint', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        hint="Hint hint, your name of choice goes here."
+      />
+    );
+  })
+  .add('Email Input w/ Hint Error', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        hintError="This is an error hint."
+      />
+    );
+  })
+  .add('Email Input w/ Hint Success', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        hintSuccess="Kaplah! This is a success hint."
+      />
+    );
+  })
+  .add('Text Input w/ Icon Start', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        // iconStart={true}
+        icon={
+          <svg className="ray-text-field__icon--start" viewBox="0 0 25 25">
+            <g id="budicon-profile-picture">
+              <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+            </g>
+          </svg>
+        }
+      />
+    );
+  })
+  .add('Text Input w/ Icon End', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        // iconEnd={true}
+        icon={
+          <svg className="ray-text-field__icon--end" viewBox="0 0 25 25">
+            <g id="budicon-profile-picture">
+              <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+            </g>
+          </svg>
+        }
+      />
+    );
+  })
+  .add('Text Input w/ Icon Start w/ Prepend', () => {
+    return (
+      <TextField
+        label="Email Address"
+        id="unique456"
+        type="email"
+        placeholder="arya.stark@winterfell.org"
+        // iconPrepend={true}
+        icon={
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 25 25"
+            style={{ height: '1rem' }}
+          >
+            <g id="budicon-profile-picture">
+              <path d="M12.5,4A4.5,4.5,0,1,0,17,8.5,4.5,4.5,0,0,0,12.5,4Zm0,8A3.5,3.5,0,1,1,16,8.5,3.504,3.504,0,0,1,12.5,12Zm0-12A12.4886,12.4886,0,0,0,5.0007,22.4834v0a12.4325,12.4325,0,0,0,14.9983,0v0q.5-.3761.9593-.7988l0,0A12.4869,12.4869,0,0,0,12.5,0Zm0,24a11.4432,11.4432,0,0,1-7.3931-2.7041,7.4887,7.4887,0,0,1,14.7863,0A11.4432,11.4432,0,0,1,12.5,24Zm8.25-3.5061a8.4871,8.4871,0,0,0-16.5,0,11.5,11.5,0,1,1,16.5,0Z" />
+            </g>
+          </svg>
+        }
+      />
+    );
+  });


### PR DESCRIPTION
**Ray Component**: https://ray.wework.com/components/text-field/

How to run locally
$ yarn storybook
$ yarn test core-react --watch

Nutshell Details:
Semantic wrapper around TexField  element:

`<TextField />`
**Default**
![Screen Shot 2019-09-16 at 12 51 26 PM](https://user-images.githubusercontent.com/45638740/64977134-d1df5a00-d880-11e9-90b3-1b77e998f811.png)

**PlaceHolder**
![Screen Shot 2019-09-16 at 1 09 07 PM](https://user-images.githubusercontent.com/45638740/64978298-300d3c80-d883-11e9-9d7f-6c3ef1f5a592.png)

**With Value**
![Screen Shot 2019-09-16 at 1 10 50 PM](https://user-images.githubusercontent.com/45638740/64978433-7ebad680-d883-11e9-911f-f25129cb470c.png)

**Error**
![Screen Shot 2019-09-16 at 12 55 58 PM](https://user-images.githubusercontent.com/45638740/64977431-5fbb4500-d881-11e9-98a2-899ed2a4b500.png)

**Icon Start**
![Screen Shot 2019-09-16 at 1 01 42 PM](https://user-images.githubusercontent.com/45638740/64977868-3949d980-d882-11e9-8cb3-94b884053184.png)

**Icon End**
![Screen Shot 2019-09-16 at 1 01 52 PM](https://user-images.githubusercontent.com/45638740/64977875-3c44ca00-d882-11e9-8fec-27b6291d192a.png)

**Icon Start Prepend**
![Screen Shot 2019-09-16 at 12 58 23 PM](https://user-images.githubusercontent.com/45638740/64977666-d9ebc980-d881-11e9-9348-3dde8e5aa506.png)

**Icon End Prepend**
![Screen Shot 2019-09-16 at 12 58 37 PM](https://user-images.githubusercontent.com/45638740/64977674-dc4e2380-d881-11e9-9b47-196bf1ce611f.png)