### PR TITLE
fix(docs-deploy): update how core-js is imported

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://ray.wework.com/",
   "scripts": {
     "dev": "yarn storybook",
-    "storybook": "start-storybook -p 6006  -s ./stories/static",
+    "storybook": "start-storybook -p 6006 -s ./stories/static",
     "build": "gulp sass:source sass:compiled components:sass:compiled scripts:es scripts:umd scripts:compiled",
     "clean": "gulp clean",
     "prebuild": "yarn clean",

--- a/packages/core/src/global/js/polyfills.js
+++ b/packages/core/src/global/js/polyfills.js
@@ -1,4 +1,1 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import 'core-js/modules/es.array.from';
-import 'core-js/modules/es.string.includes';
-/* eslint-enable import/no-extraneous-dependencies */
+import 'core-js';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,5 +5,7 @@ import boot from './global/js/boot';
 boot();
 attachAccessibilityEvents();
 
+// test
+
 export * from './components';
 export { default as settings } from './global/js/settings';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,7 +5,5 @@ import boot from './global/js/boot';
 boot();
 attachAccessibilityEvents();
 
-// test
-
 export * from './components';
 export { default as settings } from './global/js/settings';

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -67,8 +67,8 @@
     "html-loader": "^0.5.5",
     "lodash": "^4.17.14",
     "node-sass": "^4.10.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "sass-loader": "^7.1.0"
   },
   "eslintConfig": {

--- a/packages/docs-app/src/polyfills/index.js
+++ b/packages/docs-app/src/polyfills/index.js
@@ -1,15 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import 'core-js/modules/es.array.fill';
-import 'core-js/modules/es.array.from';
-import 'core-js/modules/es7.array.includes';
-import 'core-js/modules/es.math.sign';
-import 'core-js/modules/es.object.assign';
-import 'core-js/modules/es7.object.values';
-import 'core-js/modules/es.promise';
-import 'core-js/modules/es.string.includes';
-import 'core-js/modules/es.string.trim';
-import 'core-js/modules/es.symbol';
-/* eslint-enable import/no-extraneous-dependencies */
+import 'core-js';
 
 import './custom-event';
 import './element-closest';

--- a/packages/product-react/package.json
+++ b/packages/product-react/package.json
@@ -9,7 +9,7 @@
     "dev": "yarn storybook",
     "build": "gulp scripts:es scripts:umd scripts:compiled",
     "test": "jest",
-    "storybook": "start-storybook -p 6007",
+    "storybook": "start-storybook -p 6008",
     "prebuild": "rm -rf dist/",
     "netlify:build": "NODE_ENV=production build-storybook -c .storybook -o ../../.out/product-react/storybook -s ./stories/static"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,7 +5148,7 @@
     "@xtuc/long" "4.2.2"
 
 "@wework/ray-core@file:packages/core":
-  version "1.14.0"
+  version "1.16.0"
   dependencies:
     "@invisionapp/dsm-storybook" "^0.0.119"
     core-js "^3.4.1"
@@ -20884,7 +20884,7 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@16.8.6, react-dom@^16.2.0, react-dom@^16.8.1, react-dom@^16.8.3, react-dom@^16.8.4, react-dom@^16.8.6:
+react-dom@16.8.6, react-dom@^16.2.0, react-dom@^16.8.1, react-dom@^16.8.3, react-dom@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
@@ -21223,7 +21223,7 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.8.6, react@^16.2.0, react@^16.8.1, react@^16.8.3, react@^16.8.4, react@^16.8.6:
+react@16.8.6, react@^16.2.0, react@^16.8.1, react@^16.8.3, react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==


### PR DESCRIPTION
Was getting errors when deploying the docs-app:
<img width="1143" alt="Screen Shot 2019-12-02 at 2 39 07 PM" src="https://user-images.githubusercontent.com/19141291/69989437-97956880-1511-11ea-9788-c5edbba431b0.png">

This seems to be due to updates made to `core-js`: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md

This PR updates the import paths to be `core-js` so that it polyfills all `core-js` features