### PR TITLE
chore: add max worker flag to tests in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: yarn build
       - run:
           name: Run unit tests
-          command: yarn test --coverage
+          command: yarn test --coverage --maxWorkers=2
       - run:
           name: Ship test coverage report to coveralls
           command: yarn coveralls


### PR DESCRIPTION
adds a maxWorkers flag to prevent out of memory errors while running tests in CI.