### PR TITLE
Dropdown Enhancement: Markup re-usage

### DIFF
--- a/packages/core/src/components/dropdown/constants.js
+++ b/packages/core/src/components/dropdown/constants.js
@@ -44,6 +44,7 @@ export const SELECTORS = {
 export const bodyTpl = ({ value }) => {
   return {
     position: 'beforebegin',
+    selector: SELECTORS.body,
     tpl: `
       <div class="${CLASSNAMES.body}" tabindex="0">
         <div class="${CLASSNAMES.selected}">
@@ -58,6 +59,7 @@ export const bodyTpl = ({ value }) => {
 export const listTpl = ({ id }) => {
   return {
     position: 'afterend',
+    selector: SELECTORS.container,
     tpl: `
       <div class="${CLASSNAMES.container}" aria-expanded="false">
         <ul

--- a/packages/core/src/components/dropdown/index.js
+++ b/packages/core/src/components/dropdown/index.js
@@ -37,8 +37,14 @@ function wrap(el, wrapper) {
   parsedWrapper.appendChild(el);
 }
 
-function insertMarkup(_node, pos, string) {
-  _node.insertAdjacentHTML(pos, string);
+function insertMarkup(_node, pos, string, selector) {
+  const existing = _node.parentElement.querySelector(selector);
+  if (existing) {
+    const newEl = htmlToElement(string);
+    existing.parentElement.replaceChild(newEl, existing);
+  } else {
+    _node.insertAdjacentHTML(pos, string);
+  }
 }
 
 function emitEvent(target, event) {
@@ -162,11 +168,11 @@ class Dropdown {
 
   _renderMarkup() {
     markupTemplates.forEach(template => {
-      const { tpl, elements, position } = template({
+      const { tpl, elements, position, selector } = template({
         value: this._selectedOption.innerHTML,
         id: this._id
       });
-      insertMarkup(this._inputElement, position, tpl);
+      insertMarkup(this._inputElement, position, tpl, selector);
       this._cacheEl(elements);
     });
   }

--- a/packages/core/test/components/dropdown.test.js
+++ b/packages/core/test/components/dropdown.test.js
@@ -5,6 +5,7 @@ import {
   dropdownFixtureNoWrapper,
   dropdownFixtureRequired,
   dropdownFixtureWithPlaceholder,
+  dropdownFixtureWithExceedingMarkup,
   dropdownFixtureOptGroups,
   dropdownFixtureNoInput,
   dropdownFixtureSeparator,
@@ -79,6 +80,19 @@ describe('Select', () => {
 
     expect(select.value()).toBe('Charmander');
 
+    select.destroy();
+  });
+
+  test('Check that if markup already in place. It got reused not duplicated', () => {
+    const { select } = setupTest(dropdownFixtureWithExceedingMarkup());
+
+    expect(document.querySelectorAll('.ray-dropdown__body').length).toEqual(1);
+    expect(
+      document.querySelectorAll('.ray-dropdown__option-container').length
+    ).toEqual(1);
+    expect(document.querySelectorAll('.ray-dropdown__option').length).toEqual(
+      4
+    );
     select.destroy();
   });
 

--- a/packages/core/test/fixtures/dropdown/index.js
+++ b/packages/core/test/fixtures/dropdown/index.js
@@ -130,6 +130,55 @@ export function dropdownFixtureWithPlaceholder() {
   `;
 }
 
+export function dropdownFixtureWithExceedingMarkup() {
+  return html`
+    <div class="ray-dropdown">
+      <div class="ray-dropdown__wrapper">
+        <div class="ray-dropdown__body" tabindex="0">
+          <div class="ray-dropdown__selected">
+            <span class="ray-dropdown__selected-value">Squirtle</span>
+          </div>
+        </div>
+        <select class="ray-dropdown__input" id="test">
+          <option value="" data-ray-placeholder>Hi im a placeholder</option>
+          <option value="Pikachu">Pikachu</option>
+          <option value="Squirtle">Squirtle</option>
+          <option value="Charmander">Charmander</option>
+        </select>
+        <div class="ray-dropdown__option-container" aria-expanded="false">
+          <ul
+            role="listbox"
+            class="ray-dropdown__option-list"
+            id="test-example-list"
+            aria-labelledby="test-example-label"
+          >
+            <li
+              role="option"
+              data-ray-idx="0"
+              id="test-example-option-0"
+              class="ray-dropdown__option"
+            >
+              Slowpoke
+            </li>
+            <li
+              role="option"
+              data-ray-idx="5"
+              id="test-example-option-5"
+              class="ray-dropdown__option"
+            >
+              Sonichu
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <label class="ray-dropdown__label">
+        What's your favorite Pokémon?
+      </label>
+    </div>
+  `;
+}
+
 export const newOptionsFixture = `
 <option value="" data-ray-placeholder></option>
 <option value="HTML">HTML</option>


### PR DESCRIPTION
**Bug with markup duplication observed at: https://ray.wework.com/components/dropdown/**
Root cause: Due to frequent update of Gatsby React component and possibility that DOM element (which used as Key to differ instances) may fail, so possible multi-instantiation of specific component. (Which may lead to creating exceeding markup in case of Dropdown component).
See screenshot 
![Screen Shot 2020-01-10 at 4 27 27 PM](https://user-images.githubusercontent.com/5785120/72160266-b4517580-33c6-11ea-8983-dfa98c2721d7.png)

**Component enhancement as a part of solution:**
Now Dropdown will check markup that needs to be added to layout, if it already been placed (by hand, or by previous instance).
Added tests to check this specific case.

Test URL: https://deploy-preview-261--ray-docs.netlify.com/components/dropdown/